### PR TITLE
Created based template for `scatterplot` charts.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 .App {
   text-align: center;
+  background-color: darkgray;
 }
 
 .App-logo {
@@ -34,4 +35,11 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+.App-chart-title {
+  font-weight: bold;
+  text-align: left;
+  margin-top: 15px;
+  margin-left: 25px;
 }

--- a/src/components/axis/AxisBottom.tsx
+++ b/src/components/axis/AxisBottom.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { ScaleLinear } from "d3";
+
+type AxisBottomProps = {
+  xScale: ScaleLinear<number, number>;
+  pixelsPerTick: number;
+};
+
+// tick length
+const TICK_LENGTH = 6;
+
+export const AxisBottom = ({ xScale, pixelsPerTick }: AxisBottomProps) => {
+  const range = xScale.range();
+
+  const ticks = useMemo(() => {
+    const width = range[1] - range[0];
+    const numberOfTicksTarget = Math.floor(width / pixelsPerTick);
+
+    return xScale.ticks(numberOfTicksTarget).map((value) => ({
+      value,
+      xOffset: xScale(value),
+    }));
+  }, [xScale]);
+
+  return (
+    <>
+      {/* Main horizontal line */}
+      <path
+        d={["M", range[0], 0, "L", range[1], 0].join(" ")}
+        fill="none"
+        stroke="currentColor"
+      />
+
+      {/* Ticks and labels */}
+      {ticks.map(({ value, xOffset }) => (
+        <g key={value} transform={`translate(${xOffset}, 0)`}>
+          <line y2={TICK_LENGTH} stroke="currentColor" />
+          <text
+            key={value}
+            style={{
+              fontSize: "10px",
+              textAnchor: "middle",
+              transform: "translateY(20px)",
+            }}
+          >
+            {value}
+          </text>
+        </g>
+      ))}
+    </>
+  );
+};

--- a/src/components/axis/AxisLeft.tsx
+++ b/src/components/axis/AxisLeft.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { ScaleLinear } from "d3";
+
+type AxisLeftProps = {
+  yScale: ScaleLinear<number, number>;
+  pixelsPerTick: number;
+};
+
+// tick length
+const TICK_LENGTH = 6;
+
+export const AxisLeft = ({ yScale, pixelsPerTick }: AxisLeftProps) => {
+  const range = yScale.range();
+
+  const ticks = useMemo(() => {
+    const height = range[0] - range[1];
+    const numberOfTicksTarget = Math.floor(height / pixelsPerTick);
+
+    return yScale.ticks(numberOfTicksTarget).map((value) => ({
+      value,
+      yOffset: yScale(value),
+    }));
+  }, [yScale]);
+
+  return (
+    <>
+      {/* Main vertical line */}
+      <path
+        d={["M", 0, range[0], "L", 0, range[1]].join(" ")}
+        fill="none"
+        stroke="currentColor"
+      />
+
+      {/* Ticks and labels */}
+      {ticks.map(({ value, yOffset }) => (
+        <g key={value} transform={`translate(0, ${yOffset})`}>
+          <line x2={-TICK_LENGTH} stroke="currentColor" />
+          <text
+            key={value}
+            style={{
+              fontSize: "10px",
+              textAnchor: "middle",
+              transform: "translateX(-20px)",
+            }}
+          >
+            {value}
+          </text>
+        </g>
+      ))}
+    </>
+  );
+};

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -1,0 +1,215 @@
+// https://javascript.plainenglish.io/a-simple-guide-to-using-typescript-with-d3js-f0757993b968
+// https://legacy.reactjs.org/docs/composition-vs-inheritance.html
+// https://www.react-graph-gallery.com/scatter-plot
+// https://d3-graph-gallery.com/scatter.html
+
+import { useEffect, useState, MutableRefObject } from "react";
+import * as d3 from "d3";
+
+import styles from "./scatterplot.module.css";
+import useChartDimensions from "../../hooks/useChartDimensions";
+import { StripGenerator } from "./StripGenerator";
+import { AxisBottom } from "../axis/AxisBottom";
+import { AxisLeft } from "../axis/AxisLeft";
+import { InteractionData, Tooltip } from "../marks/Tooltip";
+import { Swatches } from "../legend/Swatches";
+
+// const oneMillion = 1_000_000;
+const MARGIN: {
+        top: number,
+        right: number,
+        bottom: number,
+        left: number
+    } = { 
+        top: 30,
+        right: 25,
+        bottom: 80,
+        left: 70 
+    };
+
+type D3ScatterplotChartProps = {
+    height: number;
+    data: { 
+        x: number;
+        y: number;
+        markColorField: string;
+    }[];
+    markColorScale: d3.ScaleOrdinal<any, any>;
+    xAxisLabel: string;
+    yAxisLabel: string;
+};
+
+const D3ScatterplotChart = ({ height, data, markColorScale, xAxisLabel, yAxisLabel }: D3ScatterplotChartProps) => {
+
+    const [hovered, setHovered] = useState<InteractionData | null>(null);
+    const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
+
+    const [ref, dms] = useChartDimensions({
+        marginTop: MARGIN.top,
+        marginBottom: MARGIN.bottom,
+        marginLeft: MARGIN.left,
+        marginRight: MARGIN.right
+    });
+
+    // Layout. The div size is set by the given props.
+    // The bounds (=area inside the axis) is calculated by substracting the margins
+    // @ts-expect-error
+    const boundsWidth = dms.width - MARGIN.right - MARGIN.left;
+    const boundsHeight = height - MARGIN.top - MARGIN.bottom;
+
+    // Property 'width' does not exist on type 'MutableRefObject<undefined>'.
+    // @ts-expect-error
+    const width = dms.width;
+    
+    // Create the horizontal scale and its axis generator.
+    const xScale = d3
+    .scaleLinear()
+    .domain([
+        d3.min(data, (d) => d.x) as number,
+        d3.max(data, (d) => d.x) as number
+    ]) // data points for x
+    .range([0, boundsWidth]); // axis x dimensions
+
+    const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
+
+    // Create the vertical scale and its axis generator.
+    const yScale = d3
+    .scaleLinear()
+    .domain([0, d3.max(data, (d) => d.y) as number]) // data points for y
+    .nice()
+    .range([boundsHeight, 0]); // axis y dimensions
+
+    const yAxis = d3.axisLeft(yScale);
+  
+    // Build the shapes (dots)
+    const allShapes = data.map((d, i) => {
+
+        const className = // class if the circle depends on the hover state
+            hoveredGroup && d.markColorField !== hoveredGroup
+            ? styles.scatterplotCircle + " " + styles.dimmed
+            : styles.scatterplotCircle;
+
+      return (
+        <circle
+          key={i}
+          r={5}
+          cx={xScale(d.x)}
+          cy={yScale(d.y)}
+          className={className}
+          stroke={markColorScale(d.markColorField)}
+          fill={markColorScale(d.markColorField)}
+          fillOpacity={0.6}
+          onMouseOver={() => {            
+            setHoveredGroup(d.markColorField);
+
+            setHovered({
+                xPos: xScale(d.x),
+                yPos: yScale(d.y),
+                markColorScale: markColorScale,
+                markColorFieldLegendName: "Gender",
+                markColorField: d.markColorField,
+                xAxisLabel: xAxisLabel,
+                xAxisValue: d.x,
+                yAxisLabel: yAxisLabel,
+                yAxisValue: d.y
+              });
+          }}
+          onMouseLeave={() => { 
+            setHoveredGroup(null)
+            setHovered(null)
+          }}
+        />
+      );
+    });
+
+    const handleSwatchSelect = (label: string) => {
+        (hoveredGroup === null) ? setHoveredGroup(label) : setHoveredGroup(null);
+    };
+
+    return(
+        <div
+            ref={ref as MutableRefObject<HTMLDivElement>}
+            style={{
+                height, 
+                position: "relative"
+            }}
+            className="container"
+        >                    
+            <svg
+                width={width}
+                height={height}
+                viewBox={`0 0 ${width} ${height}`}
+                className="viz"
+                shapeRendering={"crispEdges"}
+            >
+                <g
+                    width={boundsWidth}
+                    height={boundsHeight}
+                    transform={`translate(${[MARGIN.left, MARGIN.top].join(",")})`}
+                    overflow={"visible"}
+                >
+
+                    {/* graph content */}
+                    <StripGenerator width={boundsWidth} height={boundsHeight} />
+
+                    {/* legend */}
+                    <g className="legend" overflow={"visible"} transform={`translate(-10, 0)`}>
+                        <Swatches markColorScale={markColorScale} onSelect={handleSwatchSelect} />
+                    </g>
+
+                    {/* dots */}
+                    <g className="dots" overflow={"visible"}>
+                        {allShapes}
+                    </g>
+
+                    {/* Y axis */}
+                    <AxisLeft yScale={yScale} pixelsPerTick={30} />
+
+                    {/* Text label for Y axis. */}
+                    <g transform={`translate(0, ${boundsHeight / 2})`}>
+                        <text 
+                            y={-50}
+                            style={{textAnchor: "middle", fontWeight: "normal"}}
+                            transform={"rotate(-90)"}
+                        >
+                            {yAxisLabel}
+                        </text>
+                    </g>
+
+                    {/* X axis, use an additional translation to appear at the bottom */}
+                    <g transform={`translate(0, ${boundsHeight})`}>
+                        <AxisBottom xScale={xScale} pixelsPerTick={60} />
+                    </g>
+
+                    {/* Text label for X axis. */}
+                    <g transform={`translate(0, ${boundsHeight + 60})`}>
+                        <text 
+                            x={boundsWidth / 2}
+                            style={{textAnchor: "middle", fontWeight: "normal"}}
+                        >
+                            {xAxisLabel}
+                        </text>
+                    </g>
+                </g>
+            </svg>
+
+            {/* Tooltip */}
+            <div
+                style={{
+                width: boundsWidth,
+                height: boundsHeight,
+                position: "absolute",
+                top: 0,
+                left: 0,
+                pointerEvents: "none",
+                marginLeft: MARGIN.left,
+                marginTop: MARGIN.top,
+                }}
+            >
+                <Tooltip interactionData={hovered} />
+            </div>
+        </div>
+    );
+};
+
+export default D3ScatterplotChart;

--- a/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
@@ -1,0 +1,41 @@
+
+import * as d3 from "d3";
+
+import D3ScatterPlotChart from "./D3ScatterplotChart";
+import { colorScaleGender } from "../marks/Color";
+
+type ScatterplotChartWaistCircumferenceVsBMIProps = {
+    height: number;
+    data: { 
+        waistCircumference: number,
+        bodyMassIndex: number,
+        markColorField: string
+    }[];
+};
+
+const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data }: ScatterplotChartWaistCircumferenceVsBMIProps) => {
+
+    // data.map(d => console.log(d));
+
+    const scatterplotChartData = d3.map(data, (d) => {
+        return {
+            x: d.waistCircumference,
+            y: d.bodyMassIndex,
+            markColorField: d.markColorField
+        }
+    });
+
+    return (
+        <>
+        <D3ScatterPlotChart
+            height={height}
+            data={scatterplotChartData}
+            markColorScale={colorScaleGender}
+            xAxisLabel="Waist Circumference (cm)"
+            yAxisLabel="Body Mass Index (BMI)"
+        />
+        </>
+    );
+};
+
+export default ScatterplotChartWaistCircumferenceVsBMI;

--- a/src/components/charts/StripGenerator.tsx
+++ b/src/components/charts/StripGenerator.tsx
@@ -1,0 +1,31 @@
+export const StripGenerator = ({
+    width,
+    height,
+  }: {
+    width: number;
+    height: number;
+  }) => {
+    return (
+      <>
+        <defs>
+          <pattern
+            id="pattern_rkDsm"
+            patternUnits="userSpaceOnUse"
+            width="9.5"
+            height="2.5"
+            patternTransform="rotate(41)"
+          >
+            {/* #D9B9F3 */}
+            <line x1="0" y="0" x2="0" y2="9.5" stroke="#EAE8E4" strokeWidth="1" />
+          </pattern>
+        </defs>
+        <rect
+          width={width}
+          height={height}
+          fill="url(#pattern_rkDsm)"
+          opacity="1"
+        />
+      </>
+    );
+  };
+  

--- a/src/components/charts/scatterplot.module.css
+++ b/src/components/charts/scatterplot.module.css
@@ -1,0 +1,20 @@
+.scatterplotCircle {
+    fill-opacity: .3;
+    stroke-width: 2px;
+}
+
+.scatterplotCircle.dimmed {
+    filter: saturate(0);
+    opacity: .2;
+    transition: opacity, filter;
+    transition-delay: .5s;
+    transition-duration: .5s
+}
+
+.scatterplotCircle:hover {
+    cursor: pointer;
+    opacity: 1;
+    stroke: black;
+    fill-opacity: 1;
+    stroke-width: 1px;
+}

--- a/src/components/legend/Swatches.tsx
+++ b/src/components/legend/Swatches.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import * as d3 from 'd3';
+
+type SwatchesProps = {
+    markColorScale: d3.ScaleOrdinal<any, any>;
+    onSelect: Function;
+};
+
+export const Swatches = ({ markColorScale, onSelect }:SwatchesProps ) => {
+  const swatchWidth = 30;
+  const swatchHeight = 30;
+
+  const id: string = `swatches-${Math.random().toString(16).slice(2)}`;
+  const margingLeft: number = 0;
+
+  return (
+    <svg id="swatches">
+        {markColorScale.length && markColorScale.domain().map((label, index) => (
+            <g key={label} transform={`translate(${90 * index}, 25)`}>
+
+                {/* swatch color */}
+                <rect
+                    key={index}
+                    x={swatchWidth + 20}
+                    y={0}
+                    width={swatchWidth}
+                    height={swatchHeight}
+                    fill={markColorScale(label)}
+                    onClick={() => onSelect(label)}
+                />
+
+                {/* swatch label */}
+                <text
+                    key={label}
+                    x={swatchWidth + 60}
+                    y={swatchHeight - 10}
+                    style={{
+                        fontSize: "13px",
+                        textAnchor: "start"
+                    }}
+                >
+                    {label}
+                </text>            
+            </g>
+        ))}
+    </svg>
+  );
+};

--- a/src/components/marks/Color.tsx
+++ b/src/components/marks/Color.tsx
@@ -1,0 +1,7 @@
+
+import * as d3 from "d3";
+
+export const colorScaleGender = d3
+    .scaleOrdinal<string, string>()
+    .domain(['Male', 'Female'])
+    .range(["#4a58dd", "#bf3caf"]);

--- a/src/components/marks/Tooltip.tsx
+++ b/src/components/marks/Tooltip.tsx
@@ -1,0 +1,58 @@
+import * as d3 from "d3";
+import styles from "./tooltip.module.css"
+
+// Information needed to build the tooltip
+export type InteractionData = {
+  xPos: number;
+  yPos: number;
+  markColorScale: d3.ScaleOrdinal<any, any>;
+  markColorFieldLegendName: string;
+  markColorField: string;
+  xAxisLabel: string;
+  yAxisLabel: string;
+  xAxisValue: number;
+  yAxisValue: number;
+};
+
+type TooltipProps = {
+  interactionData: InteractionData | null;
+};
+
+export const Tooltip = ({ interactionData }: TooltipProps) => {
+  if (!interactionData) {
+    return null;
+  }
+
+  const { xPos, yPos, markColorScale, markColorFieldLegendName, markColorField, xAxisLabel, xAxisValue, yAxisLabel, yAxisValue } = interactionData;
+
+  let topHalfStyle: React.CSSProperties = (typeof markColorScale(markColorField) === undefined) ? { borderColor: "#cccccc" } : { borderColor: markColorScale(markColorField) };
+
+  return (
+    <div
+      className={styles.tooltip}
+      style={{
+        left: interactionData.xPos,
+        top: interactionData.yPos,
+      }}
+    >
+
+      <b className={styles.title}>Stats</b>
+
+      <div className={styles.topHalfContainer} style={topHalfStyle}>
+      <div className={styles.row}>
+          <span>{markColorFieldLegendName}</span>
+          <b>{markColorField}</b>
+        </div>
+        <div className={styles.row}>
+          <span>{xAxisLabel}</span>
+          <b>{xAxisValue}</b>
+        </div>
+        <div className={styles.row}>
+          <span>{yAxisLabel}</span>
+          <b>{yAxisValue}</b>
+        </div>
+      </div>
+
+    </div>
+  );
+};

--- a/src/components/marks/tooltip.module.css
+++ b/src/components/marks/tooltip.module.css
@@ -1,0 +1,38 @@
+.tooltip {
+    width: 356px;
+    background: #fff;
+    border: 1px solid #f5f5f5;
+    box-shadow: 3px 3px 3px rgb(0 0 0 / 10%);
+    font-size: 11px;
+    max-width: 250px;
+    padding: 10px;
+    position: absolute;
+
+    margin-left: 35px;
+    transform: translateY(-50%);
+}
+
+.title {
+    font-size: 17px;
+}
+
+.topHalfContainer {
+    border-left: solid 4px;
+    padding-left: 8px;
+    padding-top: 0px;
+}
+
+.row {
+    display: flex;
+    justify-content: space-between;
+    line-height: 20px;
+    font-size: 14px;
+}
+
+.separator {
+    width: 100%;
+    background-color: #c9c7c7;
+    height: 1px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}

--- a/src/hooks/useChartDimensions.tsx
+++ b/src/hooks/useChartDimensions.tsx
@@ -1,0 +1,121 @@
+import { EffectCallback, useEffect, useRef, MutableRefObject, useState } from "react";
+
+interface PassedChartDimensions {
+	marginTop: number;
+	marginRight: number;
+	marginBottom: number;
+	marginLeft: number;
+}
+
+interface CombinedChartDimensions {
+	height: number;
+	width: number;
+	marginTop?: number;
+	marginRight?: number;
+	marginBottom?: number;
+	marginLeft?: number;
+	dimensions: {
+		marginTop: number;
+		marginRight: number;
+		marginBottom: number;
+		marginLeft: number;
+	};
+}
+
+const combineChartDimensions = (dimensions: CombinedChartDimensions) => {
+	const parsedDimensions = {
+		...dimensions,
+		marginTop: dimensions.marginTop || 10,
+		marginRight: dimensions.marginRight || 10,
+		marginBottom: dimensions.marginBottom || 40,
+		marginLeft: dimensions.marginLeft || 75,
+	};
+	return {
+		...parsedDimensions,
+		boundedHeight: Math.max(
+			parsedDimensions.height -
+				parsedDimensions.marginTop -
+				parsedDimensions.marginBottom,
+			0
+		),
+		boundedWidth: Math.max(
+			parsedDimensions.width -
+				parsedDimensions.marginLeft -
+				parsedDimensions.marginRight,
+			0
+		),
+	};
+};
+
+const useChartDimensions = (passedSettings: PassedChartDimensions) => {
+	const ref = useRef() as MutableRefObject<HTMLDivElement>;
+	
+	const dimensions = combineChartDimensions(
+		{
+			height: 0,
+			width: 0,
+			dimensions: {
+				marginTop: passedSettings.marginTop,
+				marginRight: passedSettings.marginRight,
+				marginBottom: passedSettings.marginBottom,
+				marginLeft: passedSettings.marginLeft,
+			}
+		}
+	);
+	
+	const [width, setWidth] = useState(0);
+	const [height, setHeight] = useState(0);
+
+	useEffect(():any => {
+		if (dimensions.width && dimensions.height) return [ref, dimensions];
+
+		// const element = ref.current as unknown as Element;
+		const element = ref.current as unknown as Element;
+
+		// if (!element) return;
+
+		// Todo: Need to figure this out. Remove this code.
+		// if (element === undefined) {
+		// 	return {
+		// 		height: 0,
+		// 		width: 0,
+		// 		dimensions: {
+		// 			marginTop: passedSettings.marginTop,
+		// 			marginRight: passedSettings.marginRight,
+		// 			marginBottom: passedSettings.marginBottom,
+		// 			marginLeft: passedSettings.marginLeft,
+		// 		}
+		// 	};	
+		// }
+
+		const resizeObserver = new ResizeObserver((entries) => {
+			if (!Array.isArray(entries)) return;
+			if (!entries.length) return;
+
+			const entry = entries[0];
+
+			if (width !== entry.contentRect.width)
+				setWidth(entry.contentRect.width);
+			if (height !== entry.contentRect.height)
+				setHeight(entry.contentRect.height);
+		});
+		// resizeObserver.observe(element);
+		if (element !== undefined) {
+			resizeObserver.observe(element);
+			return () => resizeObserver.unobserve(element);
+		}
+
+		return () => undefined;
+		// return () => resizeObserver.unobserve(element);
+	}, []);
+
+	const newSettings = combineChartDimensions({
+		...dimensions,
+		width: dimensions.width || width,
+		height: dimensions.height || height,
+	});
+
+	return [ref, newSettings];
+};
+
+export default useChartDimensions;

--- a/src/index.css
+++ b/src/index.css
@@ -77,9 +77,8 @@ h2 {
 }
 
 .dashboard {
-  padding-left: 1rem;
-  padding-right: 1rem;
-  width: 100%;
+  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .wrapper {
@@ -99,11 +98,13 @@ h2 {
 .map-container,
 .pie-chart-container,
 .bar-chart-container,
+.scatterplot-chart-container,
 .card {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   gap: 10px;
+  /* margin-bottom: 1rem; */
   padding: 1rem;
   border-radius: 0.75rem;
   --tw-shadow: 0px 0px 0px 1px rgba(9, 9, 11, 0.07),
@@ -140,8 +141,9 @@ h2 {
 }
 
 @media (min-width: 1024px) {
+
   .wrapper {
-    max-width: 180rem; /* 80rem */
+    max-width: 100rem; /* 80rem */
   }
 
   .container {
@@ -165,6 +167,14 @@ h2 {
   }
 
   .bar-chart-container {
+    grid-column: span 15 / span 15;
+  }
+
+  .scatterplot-chart-container {
+    grid-column: span 15 / span 15;
+  }
+
+  .scatterplot-chart-waist-cirumference-vs-bmi {
     grid-column: span 15 / span 15;
   }
 }


### PR DESCRIPTION
- Provides a base chart for scatterplots.
- Gives an example of `Waist Circumference vs. BMI` metrics.
- Shows interactivity when user rolls mouse over dot by using a tooltip marker and highlighting similar gender attributes.
- Gender (male, female) uses color marker to help identify the dot.
-- A legend is displayed where the user can click the swatch color and the dot gender will display by group.