### PR TITLE
Interactivity: Gender Donut Chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ import ScatterplotChartBloodMeasuresVsBMI from "./components/charts/ScatterplotC
 import ScatterplotChartWaistCircumferenceVsBMI from "./components/charts/ScatterplotChartWaistCircumferenceVsBMI";
 import StackedBarChartAgeVsExercise from "./components/charts/StackedBarChartAgeVsExercise";
 
+// Import interactions
+import { onDonutChartGenderSliceClick } from "./interactions/InteractionsDonutChartGender";
+
 // interface DataItemAgeVsExercise {
 //   Age: number;
 //   No: number;
@@ -39,9 +42,13 @@ function App() {
   const [
     donutChartDataGender, setDonutChartDataGender
   ] = useState([] as Participant[]);
+
+  const [hoveredGroupDataDataBloodMeasuresVsBMI, setHoveredGroupDataDataBloodMeasuresVsBMI] = useState<string | null>(null);
   const [
     scatterplotChartDataBloodMeasuresVsBMI, setScatterplotChartDataBloodMeasuresVsBMI
   ] = useState([]);
+
+  const [hoveredGroupDataWaistCircumferenceVsBMIByGender, setHoveredGroupDataWaistCircumferenceVsBMIByGender] = useState<string | null>(null);
   const [
     scatterplotChartDataWaistCircumferenceVsBMI, setScatterplotChartDataWaistCircumferenceVsBMI
   ] = useState([]);
@@ -210,7 +217,8 @@ function App() {
                 [ 
                   [ "waistCircumference", parseFloat(participant["Waist Circumference (cm)"])],
                   [ "bodyMassIndex", parseFloat(participant["Bmxbmi"]) ],
-                  [ "markColorField", participant["Gender"] ]  
+                  [ "markColorField", participant["Gender"] ],
+                  [ "filterGender", participant["Gender"] ]
                 ]
               ) 
             })
@@ -272,6 +280,8 @@ function App() {
                               <ScatterplotChartBloodMeasuresVsBMI
                                 height={260}
                                 data={scatterplotChartDataBloodMeasuresVsBMI}
+                                hoveredGroup={hoveredGroupDataDataBloodMeasuresVsBMI}
+                                setHoveredGroup={setHoveredGroupDataDataBloodMeasuresVsBMI}
                               />
                           </div>
                       )}
@@ -295,7 +305,9 @@ function App() {
                               width={570}
                               height={278}
                               data={donutChartDataGender}
-                              onClickPieSlice={setParticipantCount}
+                              onUpdateParticipantCount={setParticipantCount}
+                              onFilterByGender={setHoveredGroupDataWaistCircumferenceVsBMIByGender}
+                              onSliceClick={[onDonutChartGenderSliceClick]}
                             />
                         </div>
                       )}
@@ -319,6 +331,8 @@ function App() {
                             <ScatterplotChartWaistCircumferenceVsBMI
                               height={300}
                               data={scatterplotChartDataWaistCircumferenceVsBMI}
+                              hoveredGroup={hoveredGroupDataWaistCircumferenceVsBMIByGender}
+                              setHoveredGroup={setHoveredGroupDataWaistCircumferenceVsBMIByGender}
                             />
                         </div>
                     )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,7 +288,7 @@ function App() {
                     <div className="left-pane">
                       {/* Scatterplot Chart - Blood Measures vs. BMI */}
                       {scatterplotChartDataBloodMeasuresVsBMI !== undefined && (
-                          <div className="card scatterplot-chart-container">
+                          <div className="card scatterplot-chart-container scatterplot-chart-blood-measures-vs-bmi">
                               <h2 className="App-chart-title">Blood Measures vs. BMI</h2>
                               <ScatterplotChartBloodMeasuresVsBMI
                                 height={260}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { onDonutChartGenderSliceClick } from "./interactions/InteractionsDonutCh
 // }
 
 interface Participant {
+  seqnIdentifiers: Set<number>;
   name: string;
   value: number;
   percentage: number;
@@ -89,6 +90,7 @@ function App() {
         .map((participant: any) => {            
           return Object.fromEntries(
             [ 
+              [ "seqn", parseInt(participant["Seqn"]) ],
               [ "age", parseFloat(participant["Age"]) ],
               [ "exercise", participant["Paq605 ( Vigorous Exercise)"] ],
             ]
@@ -142,13 +144,18 @@ function App() {
         // ---------------------------------------------------------------------------
         // Get donut `Gender` data.
         // Reference: https://www.geeksforgeeks.org/count-distinct-elements-in-an-array/
-        let uniqueGenders = new Set();
-        let uniqueParticipantsFemale = new Set();
-        let uniqueParticipantsMale = new Set();
+        let uniqueGenders = new Set<string>();
+        let uniqueParticipantsFemale = new Set<number>();
+        let uniqueParticipantsMale = new Set<number>();
         data
         .map((participant: any) => {
           return Object.fromEntries(
             [ 
+              [ "seqnIdentifiers", 
+                (participant["Gender"] === "Male") ? 
+                  uniqueParticipantsMale : 
+                  uniqueParticipantsFemale
+              ],
               // [ "name", uniqueGenders.add(participant["calcFieldGender"]) ],
               [ "name", uniqueGenders.add(participant["Gender"]) ],
               [ "value", 
@@ -165,6 +172,10 @@ function App() {
         uniqueGenders.forEach((gender) => {
           donutData.push(
             {
+              seqnIdentifiers: 
+                (gender === "Male") ? 
+                uniqueParticipantsMale:
+                uniqueParticipantsFemale,
               name: gender as string,
               value: 
                 (gender === "Male") ? 
@@ -194,6 +205,7 @@ function App() {
             .map((participant: any) => {            
               return Object.fromEntries(
                 [ 
+                  [ "seqn", participant["Seqn"] ],
                   [ "bodyMassIndex", parseFloat(participant["Bmxbmi"]) ],
                   [ "insulin", parseFloat(participant["Insulin"]) ],
                   [ "glucoseAfter2Hour", parseFloat(participant["Lbxglt(Glucose after 2 hr)"]) ],
@@ -215,6 +227,7 @@ function App() {
             .map((participant: any) => {            
               return Object.fromEntries(
                 [ 
+                  [ "seqn", participant["Seqn"] ],
                   [ "waistCircumference", parseFloat(participant["Waist Circumference (cm)"])],
                   [ "bodyMassIndex", parseFloat(participant["Bmxbmi"]) ],
                   [ "markColorField", participant["Gender"] ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ function App() {
               [ "seqn", parseInt(participant["Seqn"]) ],
               [ "age", parseFloat(participant["Age"]) ],
               [ "exercise", participant["Paq605 ( Vigorous Exercise)"] ],
+              [ "gender", participant["Gender"] ]
             ]
           ) 
         })
@@ -108,21 +109,26 @@ function App() {
         }
         
         // Aggregate data by age and exercise level
-        const ageGroupExerciseCounts = d3.rollup(
+        const ageGroupExerciseCounts: any = d3.rollup(
           dataBarAgeVsExercise,
             (v) => v.length, // Count participants
             (d) => getAgeGroup(d.age), // Group by Age Group
-            (d) => d.exercise // Group by Exercise Level
+            (d) => d.exercise, // Group by Exercise Level
+            (d) => d.gender
         );
 
         // console.log(ageGroupExerciseCounts);
 
         // Convert the data into an array of objects for easy stacking
-        const formattedData = Array.from(ageGroupExerciseCounts, ([ageGroup, exerciseMap]) => {
-            const entry = { AgeGroup: ageGroup, No: 0, Vigorous: 0 };
-            exerciseMap.forEach((count, exercise) => {
-                if (exercise === "No") entry.No = count;
-                else if (exercise === "Vigorous") entry.Vigorous = count;
+        const formattedData = Array.from(ageGroupExerciseCounts, ([ageGroup, exerciseMap, genderMap]) => {
+            const entry = { 
+              AgeGroup: ageGroup,
+              No: 0,
+              Vigorous: 0
+            };
+            exerciseMap.forEach((count: any, exercise: any) => {
+                if (exercise === "No") entry["No"] = count;
+                else if (exercise === "Vigorous") entry["Vigorous"] = count;
             });
             return entry;
         });
@@ -130,12 +136,20 @@ function App() {
 
         setBarChartDataAgeVsExerciseLevel(
           formattedData
-          .map((entry: any) => {            
+          .map((entry: any) => {    
+            let noCount = 0;
+            entry["No"].forEach((currentValue: number) => noCount += currentValue);
+            let vigorousCount = 0;
+            entry["Vigorous"].forEach((currentValue: number) => vigorousCount += currentValue);
             return Object.fromEntries(
               [ 
                 [ "ageGroup", entry["AgeGroup"] ],
-                [ "groupExerciseLevelNo", entry["No"] ],
-                [ "groupExerciseLevelVigorous", entry["Vigorous"] ]
+                [ "groupExerciseLevelNo", noCount ],
+                [ "groupExerciseLevelNoMale", entry["No"].get("Male") ],
+                [ "groupExerciseLevelNoFemale", entry["No"].get("Female") ],
+                [ "groupExerciseLevelVigorous", vigorousCount ],
+                [ "groupExerciseLevelVigorousMale", entry["Vigorous"].get("Male") ],
+                [ "groupExerciseLevelVigorousFemale", entry["Vigorous"].get("Female") ],
               ]
             ) 
           })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ interface Participant {
 
 function App() {
 
+  const [participantCount, setParticipantCount] = useState(0);
+
   const [mergedData, setMergedData] = useState<d3.DSVRowArray<string>>();
   const [
     barChartDataAgeVsExerciseLevel, setBarChartDataAgeVsExerciseLevel
@@ -54,7 +56,7 @@ function App() {
         let data = fetchedData[0];
 
         // Add calculated fields
-        data = data
+        // data = data
         // .map((d: any) => {
         //   d["calcFieldGender"] = (d["RIAGENDR"] === "1" ? "Male" : "Female");
         //   return d;
@@ -63,6 +65,10 @@ function App() {
 
         // Set the state for merged data.
         setMergedData(data);
+
+        // ---------------------------------------------------------------------------
+        // Participant Count
+        setParticipantCount(data !== undefined ? data.length : 0);
 
         // ---------------------------------------------------------------------------
         // Get bar chart `Age vs. Vigorous Exercise` data.
@@ -275,20 +281,21 @@ function App() {
 
                       {/* Total Metrics - Participants */}
                       <div className="card card-participants-container stat-card">
-                        <h2>Total Participants</h2>
+                        <h2>Participants</h2>
                         <span className="stat">
-                          {mergedData !== undefined ? mergedData.length : 0}
+                          {participantCount}
                         </span>
                       </div>
 
                       {/* Donut Chart - Gender */}
                       {donutChartDataGender !== undefined && (
                         <div className="card donut-chart-container donut-chart-gender">
-                            <h2 className="App-chart-title">Physical Exercise Engagement Among Individuals</h2>
+                            <h2 className="App-chart-title">Gender</h2>
                             <DonutChartGender
                               width={570}
                               height={278}
                               data={donutChartDataGender}
+                              onClickPieSlice={setParticipantCount}
                             />
                         </div>
                       )}

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -14,7 +14,9 @@ type D3DonutChartProps = {
   data: DataItem[];
   showPercentages: boolean;
   markColorScale: d3.ScaleOrdinal<any, any>;
-  onClickPieSlice: Function;
+  onUpdateParticipantCount: Function;
+  onFilterByGender?: Function;
+  onSliceClick: Array<Function> | [];
 };
 
 const MARGIN_X = 150;
@@ -22,7 +24,7 @@ const MARGIN_Y = 50;
 const INFLEXION_PADDING = 20; // space between donut and label inflexion point
 
 
-const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, onClickPieSlice }: D3DonutChartProps) => {
+const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, onUpdateParticipantCount, onFilterByGender, onSliceClick }: D3DonutChartProps) => {
     const [participantCount, setParticipantCount] = useState(0);
     const [toggledSlice, setToggledSlice] = useState(false);
     
@@ -83,13 +85,18 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                 // }
             }}
             onClick={(s) => {
-                console.log("toggledSlice = " + toggledSlice);
+                // console.log("toggledSlice = " + toggledSlice);
                 setToggledSlice(!toggledSlice);
+
+                // Handle interactions passed for slick click for other charts.
+                onSliceClick.forEach((func) => {
+                    func(toggledSlice, markColorScale(grp.data.name));
+                });
 
                 if (toggledSlice) {
                     
                     // Change the number for participants based on the slice selection.
-                    onClickPieSlice(grp.data.value);
+                    onUpdateParticipantCount(grp.data.value);
                     d3.select(".card-participants-container .stat").attr("style", "color: " + markColorScale(grp.data.name));
 
                     // Desaturate and turn down opacity of all slices using '.hasHighlight .slice' class.
@@ -105,6 +112,10 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                     // Add an inline styling for current selected slice.
                     d3.select(s.currentTarget)
                     .attr("style", "filter: saturate(100%); opacity: 1;");
+
+                    if (onFilterByGender !== undefined) {
+                        onFilterByGender(grp.data.name);
+                    }
                 } else {
                     
                     // Change the number for participants for the whole donut chart values.
@@ -112,7 +123,7 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                     data.forEach((slice) => {
                         totalParticipantCount += slice.value
                     })
-                    onClickPieSlice(totalParticipantCount);
+                    onUpdateParticipantCount(totalParticipantCount);
                     d3.select(".card-participants-container .stat").attr("style", null);
 
                     // Saturate and enable full opacity of all slices by removing '.hasHighlight .slice' class.
@@ -123,6 +134,10 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                     // Remove inline style for current selected slice.
                     d3.select(s.currentTarget)
                     .attr("style", null);
+
+                    if (onFilterByGender !== undefined) {
+                        onFilterByGender(null);
+                    }
                 }
             }}
         >

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -91,7 +91,7 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
 
                 // Handle interactions passed for slick click for other charts.
                 onSliceClick.forEach((func) => {
-                    func(toggledSlice, grp.data.seqnIdentifiers);
+                    func(toggledSlice, grp.data.seqnIdentifiers, grp.data.name);
                 });
 
                 if (toggledSlice) {

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -4,6 +4,7 @@ import * as d3 from "d3";
 import styles from "./donut-chart.module.css";
 
 type DataItem = {
+  seqnIdentifiers: Set<number>;
   name: string;
   value: number;
   percentage: number;
@@ -90,7 +91,7 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
 
                 // Handle interactions passed for slick click for other charts.
                 onSliceClick.forEach((func) => {
-                    func(toggledSlice, markColorScale(grp.data.name));
+                    func(toggledSlice, grp.data.seqnIdentifiers);
                 });
 
                 if (toggledSlice) {

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -14,6 +14,7 @@ type D3DonutChartProps = {
   data: DataItem[];
   showPercentages: boolean;
   markColorScale: d3.ScaleOrdinal<any, any>;
+  onClickPieSlice: Function;
 };
 
 const MARGIN_X = 150;
@@ -21,7 +22,10 @@ const MARGIN_Y = 50;
 const INFLEXION_PADDING = 20; // space between donut and label inflexion point
 
 
-const D3DonutChart = ({ width, height, data, showPercentages, markColorScale }: D3DonutChartProps) => {
+const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, onClickPieSlice }: D3DonutChartProps) => {
+    const [participantCount, setParticipantCount] = useState(0);
+    const [toggledSlice, setToggledSlice] = useState(false);
+    
     const ref = useRef<SVGGElement>(null);
     const refParent = useRef<HTMLDivElement>(null); // Todo: Need to revisit this on responsive sizing.
 
@@ -69,14 +73,57 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale }: 
             key={i}
             className={styles.slice}
             onMouseEnter={() => {
-            if (ref.current) {
-                ref.current.classList.add(styles.hasHighlight);
-            }
+                // if (ref.current) {
+                //     ref.current.classList.add(styles.hasHighlight);
+                // }
             }}
             onMouseLeave={() => {
-            if (ref.current) {
-                ref.current.classList.remove(styles.hasHighlight);
-            }
+                // if (ref.current) {
+                //     ref.current.classList.remove(styles.hasHighlight);
+                // }
+            }}
+            onClick={(s) => {
+                console.log("toggledSlice = " + toggledSlice);
+                setToggledSlice(!toggledSlice);
+
+                if (toggledSlice) {
+                    
+                    // Change the number for participants based on the slice selection.
+                    onClickPieSlice(grp.data.value);
+                    d3.select(".card-participants-container .stat").attr("style", "color: " + markColorScale(grp.data.name));
+
+                    // Desaturate and turn down opacity of all slices using '.hasHighlight .slice' class.
+                    if (ref.current) {
+                        ref.current.classList.add(styles.hasHighlight);
+                    }
+
+                    // Remove all existing inline styling for all slices previously selected.
+                    document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice) => {
+                        slice.removeAttribute("style");
+                    });
+                    
+                    // Add an inline styling for current selected slice.
+                    d3.select(s.currentTarget)
+                    .attr("style", "filter: saturate(100%); opacity: 1;");
+                } else {
+                    
+                    // Change the number for participants for the whole donut chart values.
+                    let totalParticipantCount = 0;
+                    data.forEach((slice) => {
+                        totalParticipantCount += slice.value
+                    })
+                    onClickPieSlice(totalParticipantCount);
+                    d3.select(".card-participants-container .stat").attr("style", null);
+
+                    // Saturate and enable full opacity of all slices by removing '.hasHighlight .slice' class.
+                    if (ref.current) {
+                        ref.current.classList.remove(styles.hasHighlight);
+                    }
+
+                    // Remove inline style for current selected slice.
+                    d3.select(s.currentTarget)
+                    .attr("style", null);
+                }
             }}
         >
             {slicePath && (

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -47,9 +47,10 @@ type D3ScatterplotChartProps = {
     showLegend?: boolean;
     hoveredGroup: string | null;
     setHoveredGroup: Function;
+    interactiveClassName?: string;
 };
 
-const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true, hoveredGroup, setHoveredGroup }: D3ScatterplotChartProps) => {
+const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true, hoveredGroup, setHoveredGroup, interactiveClassName }: D3ScatterplotChartProps) => {
 
     // Remove the margin spacing when the axis labels are missing to save on space.
     MARGIN.left = (showYAxis === false) ? 0 : 70;
@@ -145,6 +146,8 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
     const xAxisPixelsPerTick = boundsWidth / xAxisTicks;
     const yAxisPixelsPerTick = boundsHeight / yAxisTicks;
 
+    let svgClassName = "viz " + interactiveClassName
+
     return(
         <div
             ref={ref as MutableRefObject<HTMLDivElement>}
@@ -158,7 +161,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
                 width={width}
                 height={height}
                 viewBox={`0 0 ${width} ${height}`}
-                className="viz"
+                className={svgClassName}
                 shapeRendering={"crispEdges"}
             >
                 <g

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -33,6 +33,7 @@ type D3ScatterplotChartProps = {
         y: number;
         markColorField: string;
         filterGender: string;
+        seqn: number;
     }[];
     markColorFieldLegendName: string,
     markColorScale: d3.ScaleOrdinal<any, any>;
@@ -130,6 +131,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
             setHoveredGroup(null)
             setHovered(null)
           }}
+          data-seqn={d.seqn}
         />
       );
     });
@@ -223,9 +225,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
                     {/* X axis - Add separator line, except after the last plot (*/}
                     {!showXAxis && (
                         <>
-                        <svg>
-                            <line x1={0} x2={boundsWidth} y1={boundsHeight} y2={boundsHeight} stroke={"gray"} strokeWidth={1} strokeDasharray={"4, 4"} />
-                        </svg>
+                            <line x1={0} x2={boundsWidth} y1={boundsHeight} y2={boundsHeight} stroke={"gray"} strokeWidth={"4"}  strokeDasharray={"4, 4"} />
                         </>
                     )}
                 </g>

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -32,6 +32,7 @@ type D3ScatterplotChartProps = {
         x: number;
         y: number;
         markColorField: string;
+        filterGender: string;
     }[];
     markColorFieldLegendName: string,
     markColorScale: d3.ScaleOrdinal<any, any>;
@@ -43,16 +44,18 @@ type D3ScatterplotChartProps = {
     showYAxis?: boolean;
     legendAlign?: string;
     showLegend?: boolean;
+    hoveredGroup: string | null;
+    setHoveredGroup: Function;
 };
 
-const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true }: D3ScatterplotChartProps) => {
+const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true, hoveredGroup, setHoveredGroup }: D3ScatterplotChartProps) => {
 
     // Remove the margin spacing when the axis labels are missing to save on space.
     MARGIN.left = (showYAxis === false) ? 0 : 70;
     MARGIN.bottom = (showXAxis === false) ? 0 : 80;
 
     const [hovered, setHovered] = useState<InteractionData | null>(null);
-    const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
+    // const [hoveredGroup, setHoveredGroup] = useState<string | null>(null); 
 
     const [ref, dms] = useChartDimensions({
         marginTop: MARGIN.top,
@@ -90,7 +93,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
     .range([boundsHeight, 0]); // axis y dimensions
 
     const yAxis = d3.axisLeft(yScale);
-  
+
     // Build the shapes (dots)
     const allShapes = data.map((d, i) => {
 
@@ -109,9 +112,8 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
           stroke={markColorScale(d.markColorField)}
           fill={markColorScale(d.markColorField)}
           fillOpacity={0.6}
-          onMouseOver={() => {            
+          onMouseOver={() => {
             setHoveredGroup(d.markColorField);
-
             setHovered({
                 xPos: xScale(d.x),
                 yPos: yScale(d.y),

--- a/src/components/charts/D3StackedBarChart.tsx
+++ b/src/components/charts/D3StackedBarChart.tsx
@@ -128,8 +128,22 @@ const D3StackedBarChart = ({
     // ref={ref as MutableRefObject<HTMLDivElement>}
     const rectangles = series.map((subgroup, i) => {
         return (
-            <g key={i}>
+            <g id={"barSubgroup" + i} className={["barSubgroup"].join(" ")} key={i}>
                 {subgroup.map((group, j) => {
+                    let dataExerciseLevel = 0;
+                    let dataExerciseLevelMale = 0;
+                    let dataExerciseLevelFemale = 0;
+
+                    if (subgroup.key === "No") {
+                        dataExerciseLevel = group.data.No
+                        dataExerciseLevelMale = group.data.NoMale;
+                        dataExerciseLevelFemale = group.data.NoFemale;
+                    } else if (subgroup.key === "Vigorous") {
+                        dataExerciseLevel = group.data.Vigorous
+                        dataExerciseLevelMale = group.data.VigorousMale;
+                        dataExerciseLevelFemale = group.data.VigorousFemale;
+                    }
+
                     return (
                         <rect
                             key={j}
@@ -145,6 +159,14 @@ const D3StackedBarChart = ({
                             onMouseLeave={() => {
                                 // setHovered(null);
                             }}
+                            data-x={xScale(group[0])}
+                            data-agegroup={group.data.x.toString()}
+                            data-execlevel={dataExerciseLevel}
+                            data-execlevel-xscale={xScale(dataExerciseLevel)}
+                            data-execlevel-male={dataExerciseLevelMale}
+                            data-execlevel-male-xscale={xScale(dataExerciseLevelMale)}
+                            data-execlevel-female={dataExerciseLevelFemale}
+                            data-execlevel-female-xscale={xScale(dataExerciseLevelFemale)}
                         ></rect>
                     );
                 })}
@@ -156,7 +178,7 @@ const D3StackedBarChart = ({
         return null;
     };
     
-    const legendOffsetX = (legendAlign === "right" ? boundsWidth - 140 : 0 );
+    const legendOffsetX = (legendAlign === "right" ? boundsWidth - 115 : 0 );
 
     const xAxisPixelsPerTick = boundsWidth / xAxisTicks;
     const yAxisPixelsPerTick = boundsHeight / yAxisTicks;

--- a/src/components/charts/DonutChartGender.tsx
+++ b/src/components/charts/DonutChartGender.tsx
@@ -14,10 +14,12 @@ type DonutChartGenderProps = {
     width: number;
     height: number;
     data: DataItem[];
-    onClickPieSlice: Function;
+    onUpdateParticipantCount: Function;
+    onFilterByGender: Function;
+    onSliceClick: Array<Function> | [];
 };
 
-const DonutChartGender = ({ width, height, data, onClickPieSlice }: DonutChartGenderProps) => {
+const DonutChartGender = ({ width, height, data, onUpdateParticipantCount, onFilterByGender, onSliceClick }: DonutChartGenderProps) => {
 
     return (
         <>
@@ -27,7 +29,9 @@ const DonutChartGender = ({ width, height, data, onClickPieSlice }: DonutChartGe
             data={data}
             showPercentages={true}
             markColorScale={colorScaleGender}
-            onClickPieSlice={onClickPieSlice}
+            onUpdateParticipantCount={onUpdateParticipantCount}
+            onFilterByGender={onFilterByGender}
+            onSliceClick={onSliceClick}
         />
         </>
     );

--- a/src/components/charts/DonutChartGender.tsx
+++ b/src/components/charts/DonutChartGender.tsx
@@ -14,9 +14,10 @@ type DonutChartGenderProps = {
     width: number;
     height: number;
     data: DataItem[];
+    onClickPieSlice: Function;
 };
 
-const DonutChartGender = ({ width, height, data }: DonutChartGenderProps) => {
+const DonutChartGender = ({ width, height, data, onClickPieSlice }: DonutChartGenderProps) => {
 
     return (
         <>
@@ -26,6 +27,7 @@ const DonutChartGender = ({ width, height, data }: DonutChartGenderProps) => {
             data={data}
             showPercentages={true}
             markColorScale={colorScaleGender}
+            onClickPieSlice={onClickPieSlice}
         />
         </>
     );

--- a/src/components/charts/DonutChartGender.tsx
+++ b/src/components/charts/DonutChartGender.tsx
@@ -5,6 +5,7 @@ import D3DonutChart from "./D3DonutChart";
 import { colorScaleGender } from "../marks/Color";
 
 type DataItem = {
+    seqnIdentifiers: Set<number>;
     name: string;
     value: number;
     percentage: number;

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -66,6 +66,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             showXAxis={false}
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
+            interactiveClassName={"chart-1"}
             
         />
         <D3ScatterPlotChart
@@ -80,6 +81,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             showLegend={false}
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
+            interactiveClassName={"chart-2"}
         />
         <D3ScatterPlotChart
             height={height+70}
@@ -93,6 +95,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             showLegend={false}
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
+            interactiveClassName={"chart-3"}
         />
         </>
     );

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -7,6 +7,7 @@ import { colorScaleGender, colorScaleDiabetesDiagnosisStatus } from "../marks/Co
 type ScatterplotChartBloodMeasuresVsBMIProps = {
     height: number;
     data: { 
+        seqn: number;
         insulin: number;
         glucoseAfter2Hour: number;
         glucoseFasting: number;
@@ -27,7 +28,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             x: d.bodyMassIndex,
             y: d.glucoseFasting,
             markColorField: d.markColorField,
-            filterGender: d.filterGender
+            filterGender: d.filterGender,
+            seqn: d.seqn
         }
     });
 
@@ -36,7 +38,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             x: d.bodyMassIndex,
             y: d.glucoseAfter2Hour,
             markColorField: d.markColorField,
-            filterGender: d.filterGender
+            filterGender: d.filterGender,
+            seqn: d.seqn
         }
     });
 
@@ -45,7 +48,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             x: d.bodyMassIndex,
             y: d.insulin,
             markColorField: d.markColorField,
-            filterGender: d.filterGender
+            filterGender: d.filterGender,
+            seqn: d.seqn
         }
     });
 

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -12,10 +12,13 @@ type ScatterplotChartBloodMeasuresVsBMIProps = {
         glucoseFasting: number;
         bodyMassIndex: number;
         markColorField: string;
+        filterGender: string;
     }[];
+    hoveredGroup: string | null;
+    setHoveredGroup: Function;
 };
 
-const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBloodMeasuresVsBMIProps) => {
+const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHoveredGroup }: ScatterplotChartBloodMeasuresVsBMIProps) => {
 
     // data.map(d => console.log(d));
 
@@ -23,7 +26,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
         return {
             x: d.bodyMassIndex,
             y: d.glucoseFasting,
-            markColorField: d.markColorField
+            markColorField: d.markColorField,
+            filterGender: d.filterGender
         }
     });
 
@@ -31,7 +35,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
         return {
             x: d.bodyMassIndex,
             y: d.glucoseAfter2Hour,
-            markColorField: d.markColorField
+            markColorField: d.markColorField,
+            filterGender: d.filterGender
         }
     });
 
@@ -39,7 +44,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
         return {
             x: d.bodyMassIndex,
             y: d.insulin,
-            markColorField: d.markColorField
+            markColorField: d.markColorField,
+            filterGender: d.filterGender
         }
     });
 
@@ -54,6 +60,9 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
             yAxisLabel="Fasting Blood Glucose"
             yAxisTicks={8}
             showXAxis={false}
+            hoveredGroup={hoveredGroup}
+            setHoveredGroup={setHoveredGroup}
+            
         />
         <D3ScatterPlotChart
             height={height}
@@ -65,6 +74,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
             yAxisTicks={12}
             showXAxis={false}
             showLegend={false}
+            hoveredGroup={hoveredGroup}
+            setHoveredGroup={setHoveredGroup}
         />
         <D3ScatterPlotChart
             height={height+70}
@@ -76,6 +87,8 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data }: ScatterplotChartBl
             xAxisTicks={13}
             yAxisTicks={10}
             showLegend={false}
+            hoveredGroup={hoveredGroup}
+            setHoveredGroup={setHoveredGroup}
         />
         </>
     );

--- a/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
@@ -7,6 +7,7 @@ import { colorScaleGender } from "../marks/Color";
 type ScatterplotChartWaistCircumferenceVsBMIProps = {
     height: number;
     data: { 
+        seqn: number;
         waistCircumference: number;
         bodyMassIndex: number;
         markColorField: string;
@@ -25,7 +26,8 @@ const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data, hoveredGroup, s
             x: d.waistCircumference,
             y: d.bodyMassIndex,
             markColorField: d.markColorField,
-            filterGender: d.filterGender
+            filterGender: d.filterGender,
+            seqn: d.seqn
         }
     });
 

--- a/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
@@ -7,13 +7,16 @@ import { colorScaleGender } from "../marks/Color";
 type ScatterplotChartWaistCircumferenceVsBMIProps = {
     height: number;
     data: { 
-        waistCircumference: number,
-        bodyMassIndex: number,
-        markColorField: string
+        waistCircumference: number;
+        bodyMassIndex: number;
+        markColorField: string;
+        filterGender: string;
     }[];
+    hoveredGroup: string | null;
+    setHoveredGroup: Function;
 };
 
-const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data }: ScatterplotChartWaistCircumferenceVsBMIProps) => {
+const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data, hoveredGroup, setHoveredGroup }: ScatterplotChartWaistCircumferenceVsBMIProps) => {
 
     // data.map(d => console.log(d));
 
@@ -21,7 +24,8 @@ const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data }: ScatterplotCh
         return {
             x: d.waistCircumference,
             y: d.bodyMassIndex,
-            markColorField: d.markColorField
+            markColorField: d.markColorField,
+            filterGender: d.filterGender
         }
     });
 
@@ -37,6 +41,8 @@ const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data }: ScatterplotCh
             xAxisTicks={20}
             yAxisTicks={10}
             legendAlign="left"
+            hoveredGroup={hoveredGroup}
+            setHoveredGroup={setHoveredGroup}
         />
         </>
     );

--- a/src/components/charts/StackedBarChartAgeVsExercise.tsx
+++ b/src/components/charts/StackedBarChartAgeVsExercise.tsx
@@ -13,7 +13,11 @@ type StackedBarChartAgeVsExerciseProps = {
     data: {
         ageGroup: string;
         groupExerciseLevelNo: number;
+        groupExerciseLevelNoMale: number;
+        groupExerciseLevelNoFemale: number;
         groupExerciseLevelVigorous: number;
+        groupExerciseLevelVigorousMale: number;
+        groupExerciseLevelVigorousFemale: number;
         markColorField: string;
     }[];
 };
@@ -29,7 +33,11 @@ const StackedBarChartAgeVsExercise = ({ height, data }: StackedBarChartAgeVsExer
         return {
             x: d.ageGroup,
             No: d.groupExerciseLevelNo,
-            Vigorous: d.groupExerciseLevelVigorous
+            NoMale: d.groupExerciseLevelNoMale,
+            NoFemale: d.groupExerciseLevelNoFemale,
+            Vigorous: d.groupExerciseLevelVigorous,
+            VigorousMale: d.groupExerciseLevelVigorousMale,
+            VigorousFemale: d.groupExerciseLevelVigorousFemale
         }
     });
 

--- a/src/components/charts/donut-chart.module.css
+++ b/src/components/charts/donut-chart.module.css
@@ -15,9 +15,9 @@
     opacity: 0.2;
 }
 
-.container.hasHighlight .slice:hover {
+/* .container.hasHighlight .slice:hover {
     filter: saturate(100%);
     opacity: 1;
-}
+} */
 
 

--- a/src/components/marks/Color.tsx
+++ b/src/components/marks/Color.tsx
@@ -14,4 +14,4 @@ export const colorScaleDiabetesDiagnosisStatus = d3
 export const colorScaleExerciseLevel = d3
     .scaleOrdinal<string, string>()
     .domain(["No", "Vigorous"])
-    .range(["#ae7aa1", "#59a14f"]);
+    .range(["#75654D", "#F5A326"]);

--- a/src/index.css
+++ b/src/index.css
@@ -138,7 +138,7 @@ text {
 .card .stat {
   font-size: 3rem;
   font-weight: 600;
-  color: #1ca4d9;
+  color: #474f53;
 }
 
 .labels text {

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -6,6 +6,71 @@ import { colorScaleGender } from "../components/marks/Color";
 
 export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>) {
     // console.log("toggledSlice ", toggledSlice);
+
+    // Handle interactions for `Blood Measures vs. BMI` scatterplot chart.
+    // ------------------------------------------------------------------------
+    if (toggledSlice) {
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-1")
+        .select(".dots")
+        .selectAll("circle")
+            .filter(function(d: SVGCircleElement) { 
+                return !(selectedSeqnIdentifiers.has(this.dataset.seqn));
+            })
+            .transition().duration(1000)
+            .attr("r", 0);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-2")
+        .select(".dots")
+        .selectAll("circle")
+            .filter(function(d: SVGCircleElement) { 
+                return !(selectedSeqnIdentifiers.has(this.dataset.seqn));
+            })
+            .transition().duration(1000)
+            .attr("r", 0);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-3")
+        .select(".dots")
+        .selectAll("circle")
+            .filter(function(d: SVGCircleElement) { 
+                return !(selectedSeqnIdentifiers.has(this.dataset.seqn));
+            })
+            .transition().duration(1000)
+            .attr("r", 0);
+            
+    } else {
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-1")
+        .select(".dots")
+        .selectAll("circle")
+            .transition().duration(1000)
+            .attr("r", 5);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-2")
+        .select(".dots")
+        .selectAll("circle")
+            .transition().duration(1000)
+            .attr("r", 5);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .select(".chart-3")
+        .select(".dots")
+        .selectAll("circle")
+            .transition().duration(1000)
+            .attr("r", 5);
+    }
+
+    // Handle interactions for `Waist Circumference vs. BMI` scatterplot chart.
+    // ------------------------------------------------------------------------
     if (toggledSlice) {
         d3
         .select(".scatterplot-chart-waist-cirumference-vs-bmi")

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -1,0 +1,27 @@
+// @ts-nocheck
+
+import * as d3 from "d3";
+
+import { colorScaleGender } from "../components/marks/Color";
+
+export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedColor: string) {
+    // console.log("toggledSlice ", toggledSlice);
+    if (toggledSlice) {
+        d3
+        .select(".scatterplot-chart-waist-cirumference-vs-bmi")
+        .select(".dots")
+        .selectAll("circle")
+            .filter(function(d: SVGCircleElement) { 
+                return this.attributes.fill.value !== selectedColor;
+            })
+            .transition().duration(1000)
+            .attr("r", 0);
+    } else {
+        d3
+        .select(".scatterplot-chart-waist-cirumference-vs-bmi")
+        .select(".dots")
+        .selectAll("circle")
+            .transition().duration(1000)
+            .attr("r", 5);
+    }
+}

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -4,7 +4,7 @@ import * as d3 from "d3";
 
 import { colorScaleGender } from "../components/marks/Color";
 
-export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>) {
+export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>, sliceName: string) {
     // console.log("toggledSlice ", toggledSlice);
 
     // Handle interactions for `Blood Measures vs. BMI` scatterplot chart.
@@ -88,5 +88,88 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
         .selectAll("circle")
             .transition().duration(1000)
             .attr("r", 5);
+    }
+
+
+    // Handle interactions for `Physical Workout vs. Age` scatterplot chart.
+    // ------------------------------------------------------------------------
+    if (toggledSlice) {
+
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        .select("#barSubgroup0")
+        .selectAll("rect")
+            .transition().duration(1000)
+            .attr("width", function(d: SVGRectElement) { 
+                let sliceExecLevelXScale: number = 0;
+                if (sliceName.toLowerCase() == "male") {
+                    sliceExecLevelXScale = this.dataset.execlevelMaleXscale;
+                } else if (sliceName.toLowerCase() == "female") {
+                    sliceExecLevelXScale = this.dataset.execlevelFemaleXscale;
+                }
+                return sliceExecLevelXScale;
+            });
+
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        .select("#barSubgroup1")
+        .selectAll("rect")
+            .transition().duration(1000)
+            .attr("x", function(d: SVGRectElement) {
+                let barSubgroup0X = 
+                    d3
+                    .select(".bar-chart-age-vs-exercise-level")
+                    .select("#barSubgroup0")
+                    .select("[data-agegroup='≤17']")
+                    .attr("x");
+    
+                let barSubgroup0Width = 
+                    d3
+                    .select(".bar-chart-age-vs-exercise-level")
+                    .select("#barSubgroup0")
+                    .select("[data-agegroup='" + this.dataset.agegroup + "']")
+                    .attr("width");
+    
+                let sliceExecLevelXScale: number = 0;
+                if (sliceName.toLowerCase() == "male") {
+                    sliceExecLevelXScale = 
+                    d3
+                    .select(".bar-chart-age-vs-exercise-level")
+                    .select("#barSubgroup0")
+                    .select("[data-agegroup='" + this.dataset.agegroup + "']")
+                    .attr("data-execlevel-male-xscale");
+                } else if (sliceName.toLowerCase() == "female") {
+                    sliceExecLevelXScale = 
+                    d3
+                    .select(".bar-chart-age-vs-exercise-level")
+                    .select("#barSubgroup0")
+                    .select("[data-agegroup='" + this.dataset.agegroup + "']")
+                    .attr("data-execlevel-female-xscale");
+                }
+
+                return barSubgroup0X + sliceExecLevelXScale;
+            })
+            .attr("width", function(d: SVGRectElement) { 
+                let sliceExecLevelXScale: number = 0;
+                if (sliceName.toLowerCase() == "male") {
+                    sliceExecLevelXScale = this.dataset.execlevelMaleXscale;
+                } else if (sliceName.toLowerCase() == "female") {
+                    sliceExecLevelXScale = this.dataset.execlevelFemaleXscale;
+                }
+                return sliceExecLevelXScale;
+            });
+
+    } else {
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        .selectAll(".barSubgroup")
+        .selectAll("rect")
+            .transition().duration(2000)
+            .attr("x", function(d: SVGRectElement) { 
+                return (this.dataset.x);
+            })
+            .attr("width", function(d: SVGRectElement) { 
+                return (this.dataset.execlevelXscale);
+            });
     }
 }

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -4,7 +4,7 @@ import * as d3 from "d3";
 
 import { colorScaleGender } from "../components/marks/Color";
 
-export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedColor: string) {
+export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>) {
     // console.log("toggledSlice ", toggledSlice);
     if (toggledSlice) {
         d3
@@ -12,7 +12,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedColo
         .select(".dots")
         .selectAll("circle")
             .filter(function(d: SVGCircleElement) { 
-                return this.attributes.fill.value !== selectedColor;
+                return !(selectedSeqnIdentifiers.has(this.dataset.seqn));
             })
             .transition().duration(1000)
             .attr("r", 0);


### PR DESCRIPTION
- [x] When selecting a gender chunk, adjust the participant count to reflect the count of gender selected.

**Change:** https://github.com/ztraboo/cpsc-6030-course-project/commit/1ef8b22e4069632017e41a23fa90a0800b68d28d

![gender-slice-selection-update-participant-number](https://github.com/user-attachments/assets/70f2f7aa-1c62-4af0-9196-c2eb5f380c07)

- [x] When selecting a gender chuck, adjust **Blood Measures vs. BMI** scatter plot chart to reflect the selected gender.

**Changes:** https://github.com/ztraboo/cpsc-6030-course-project/pull/27/commits/3b88934892cf2a850f345b941a25256726efb4f6

![gender-slice-selection-blood-measures-vs-bmi](https://github.com/user-attachments/assets/5aea4156-db4f-4b12-ac19-210b611eb83f)

- [x] When selecting a gender chuck, adjust **Waist Circumference vs. BMI** scatter plot chart to reflect the selected gender.

**Changes:** https://github.com/ztraboo/cpsc-6030-course-project/pull/27/commits/9bd7c51fc3d599f63983592a860e49f5db59df8b https://github.com/ztraboo/cpsc-6030-course-project/pull/27/commits/2ed076b2691505f8aaef878bcbf293de47ecdbfa

![gender-slice-selection-update-waist-circumference-vs-bmi](https://github.com/user-attachments/assets/cb4f7561-9cce-4665-a576-e54c0f972c2f)

Interaction between **Blood Measures vs. BMI** scatter plot chart between mouse over on a point that has similar groupings.

![blood-measures-vs-bmi-interaction-on-mouse-over](https://github.com/user-attachments/assets/04937451-227b-4c85-a3c6-f2afd613244b)


- [x] When selecting a gender chuck, adjust **Physical Workout vs. Age** stacked bar chart to reflect the selected gender.

https://github.com/ztraboo/cpsc-6030-course-project/pull/27/commits/bc0dc8b70ec5e9dffb255ae9ead826950be81a78

![gender-slice-selection-update-physical-workout-vs-age](https://github.com/user-attachments/assets/5112c797-b34c-4c7b-bd8b-c501f7bcf23a)
