### PR TITLE
`Blood Measures vs. BMI` dot selection interactivity.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import StackedBarChartAgeVsExercise from "./components/charts/StackedBarChartAge
 
 // Import interactions
 import { onDonutChartGenderSliceClick } from "./interactions/InteractionsDonutChartGender";
+import { onScatterplotChartBloodMeasuresVsBMIClick } from "./interactions/InteractionsScatterplotChartBloodMeasuresVsBMI";
 
 // interface DataItemAgeVsExercise {
 //   Age: number;
@@ -309,6 +310,7 @@ function App() {
                                 data={scatterplotChartDataBloodMeasuresVsBMI}
                                 hoveredGroup={hoveredGroupDataDataBloodMeasuresVsBMI}
                                 setHoveredGroup={setHoveredGroupDataDataBloodMeasuresVsBMI}
+                                onPointClick={[onScatterplotChartBloodMeasuresVsBMIClick]}
                               />
                           </div>
                       )}
@@ -360,6 +362,7 @@ function App() {
                               data={scatterplotChartDataWaistCircumferenceVsBMI}
                               hoveredGroup={hoveredGroupDataWaistCircumferenceVsBMIByGender}
                               setHoveredGroup={setHoveredGroupDataWaistCircumferenceVsBMIByGender}
+                              onPointClick={[]}
                             />
                         </div>
                     )}

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -63,7 +63,7 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
         const inflexionPoint = arcGenerator.centroid(inflexionInfo);
 
         const isRightLabel = inflexionPoint[0] > 0;
-        const labelPosX = inflexionPoint[0] + 50 * (isRightLabel ? 1 : -1);
+        const labelPosX = inflexionPoint[0] + 25 * (isRightLabel ? 1 : -1);
         const textAnchor = isRightLabel ? "start" : "end";
         const label = 
             grp.data.name + 
@@ -89,7 +89,7 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                 // console.log("toggledSlice = " + toggledSlice);
                 setToggledSlice(!toggledSlice);
 
-                // Handle interactions passed for slick click for other charts.
+                // Handle interactions passed for slice click for other charts.
                 onSliceClick.forEach((func) => {
                     func(toggledSlice, grp.data.seqnIdentifiers, grp.data.name);
                 });

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -48,9 +48,12 @@ type D3ScatterplotChartProps = {
     hoveredGroup: string | null;
     setHoveredGroup: Function;
     interactiveClassName?: string;
+    onPointClick: Array<Function> | [];
 };
 
-const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true, hoveredGroup, setHoveredGroup, interactiveClassName }: D3ScatterplotChartProps) => {
+const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorScale, xAxisLabel, yAxisLabel, xAxisTicks=30, yAxisTicks=30, showXAxis=true, showYAxis=true, legendAlign="right", showLegend=true, hoveredGroup, setHoveredGroup, interactiveClassName, onPointClick }: D3ScatterplotChartProps) => {
+
+    const [toggledPoint, setToggledPoint] = useState(false);
 
     // Remove the margin spacing when the axis labels are missing to save on space.
     MARGIN.left = (showYAxis === false) ? 0 : 70;
@@ -132,6 +135,15 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
             setHoveredGroup(null)
             setHovered(null)
           }}
+          onClick={(x) => {
+            setToggledPoint(!toggledPoint);
+
+            // Handle interactions passed for point click for other blood measure charts.
+            onPointClick.forEach((func) => {
+                func(toggledPoint, d, markColorScale, xScale, yScale);
+            });
+
+          }}
           data-seqn={d.seqn}
         />
       );
@@ -163,6 +175,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
                 viewBox={`0 0 ${width} ${height}`}
                 className={svgClassName}
                 shapeRendering={"crispEdges"}
+                overflow={"visible"}
             >
                 <g
                     width={boundsWidth}
@@ -228,7 +241,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
                     {/* X axis - Add separator line, except after the last plot (*/}
                     {!showXAxis && (
                         <>
-                            <line x1={0} x2={boundsWidth} y1={boundsHeight} y2={boundsHeight} stroke={"gray"} strokeWidth={"4"}  strokeDasharray={"4, 4"} />
+                            <line x1={0} x2={boundsWidth} y1={boundsHeight} y2={boundsHeight} stroke={"gray"} strokeWidth={"2"}  strokeDasharray={"4, 4"} />
                         </>
                     )}
                 </g>

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -17,9 +17,10 @@ type ScatterplotChartBloodMeasuresVsBMIProps = {
     }[];
     hoveredGroup: string | null;
     setHoveredGroup: Function;
+    onPointClick: Array<Function> | [];
 };
 
-const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHoveredGroup }: ScatterplotChartBloodMeasuresVsBMIProps) => {
+const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHoveredGroup, onPointClick }: ScatterplotChartBloodMeasuresVsBMIProps) => {
 
     // data.map(d => console.log(d));
 
@@ -67,7 +68,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
             interactiveClassName={"chart-1"}
-            
+            onPointClick={onPointClick}
         />
         <D3ScatterPlotChart
             height={height}
@@ -82,6 +83,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
             interactiveClassName={"chart-2"}
+            onPointClick={onPointClick}
         />
         <D3ScatterPlotChart
             height={height+70}
@@ -96,6 +98,7 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
             interactiveClassName={"chart-3"}
+            onPointClick={onPointClick}
         />
         </>
     );

--- a/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
@@ -15,9 +15,10 @@ type ScatterplotChartWaistCircumferenceVsBMIProps = {
     }[];
     hoveredGroup: string | null;
     setHoveredGroup: Function;
+    onPointClick: Array<Function> | [];
 };
 
-const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data, hoveredGroup, setHoveredGroup }: ScatterplotChartWaistCircumferenceVsBMIProps) => {
+const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data, hoveredGroup, setHoveredGroup, onPointClick }: ScatterplotChartWaistCircumferenceVsBMIProps) => {
 
     // data.map(d => console.log(d));
 
@@ -45,6 +46,7 @@ const ScatterplotChartWaistCircumferenceVsBMI = ({ height, data, hoveredGroup, s
             legendAlign="left"
             hoveredGroup={hoveredGroup}
             setHoveredGroup={setHoveredGroup}
+            onPointClick={onPointClick}
         />
         </>
     );

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -120,7 +120,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
                     d3
                     .select(".bar-chart-age-vs-exercise-level")
                     .select("#barSubgroup0")
-                    .select("[data-agegroup='≤17']")
+                    .select("[data-agegroup='" + this.dataset.agegroup + "']")
                     .attr("x");
     
                 let barSubgroup0Width = 

--- a/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
@@ -1,0 +1,103 @@
+// @ts-nocheck
+
+import * as d3 from "d3";
+
+export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean, d: SVGCircleElement, markColorScale: d3.ScaleOrdinal<any, any>, xScale: d3.ScaleLinear, yScale: d3.ScaleLinear) {
+
+    if (!toggledPoint) {
+            
+        // ----------------------------------------------
+
+        // Hide all points that are not selected.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("filter", "saturate(0)")
+            .style("opacity", 0);
+            
+        // Change the highlight of the selected dots between the charts.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("[data-seqn='" + d.seqn + "']")
+            .transition().duration(1000)
+            .style("stroke", "black")
+            .style("stroke-width", "4px")
+            .style("opacity", 1)
+            .style("fill-opacity", 0.8)
+            .style("filter", "saturate(1)")
+            .attr("r", 8)
+            .attr("data-selected-dot", true);
+
+        // Draw the line between the selected dots. The delay of 1 second is necessary.
+        setTimeout(() => {
+            let dataSelectedPoints = [];
+
+            const elements = document.querySelectorAll('[data-selected-dot]');
+
+            elements.forEach(element => {
+                const rect = element.getBoundingClientRect();
+                // console.log("X: " + rect.x + ", Y: " + rect.y);
+
+                dataSelectedPoints.push(
+                    {
+                        x: rect.x,
+                        y: rect.y
+                    }
+                )
+            });
+
+            const lineGenerator = 
+            d3.
+            line()
+            .x((d: any) => d.x) // Scalar is not needed because the client x value.
+            .y((d: any) => d.y) // Scalar is not needed because the client y value.
+
+            const svg = 
+            d3
+            .select(".scatterplot-chart-blood-measures-vs-bmi")
+            .select(".chart-1")
+            
+            const group = 
+            svg
+            .append("g")
+                .attr("transform", "translate(-18, -66)")
+                .attr("overflow", "visible");
+
+            group
+            .append("path")
+            .datum(dataSelectedPoints) // Bind your data to the path element
+            .attr("d", lineGenerator) // Use the line generator to create the path
+            .attr("stroke", "#399D3E") // Set the line color
+            .attr("stroke-width", 4) // Set the line width
+            .attr("stroke-dasharray", "4, 8, 4")
+            .attr("data-selected-path", "true"); 
+            }, 1000);
+
+    } else {
+        // Hide all points that are not selected.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("filter", null)
+            .style("opacity", null);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("[data-seqn='" + d.seqn + "']")
+            .transition().duration(1000)
+            .style("stroke", markColorScale(d.markColorField))
+            .style("stroke-width", "2px")
+            .style("fill-opacity", 0.3)
+            .attr("r", 5)
+            .attr("data-selected-dot", null);
+
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll("[data-selected-path='true']")
+            .remove();
+    }
+}


### PR DESCRIPTION
When clicking an individual dot perform the following actions:
- Change radial thickness or color to show dots in other scatterplot charts for association.
- Have a line link the dots and dim the other points.

![blood-measures-vs-bmi-interaction-on-point-click](https://github.com/user-attachments/assets/7e0f88ff-902e-4820-8bbe-e5a8bec6e03c)

