### PR TITLE
Interaction for Stacked Bar Chart of `Physical Workout vs. Age Group`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "d3": "^7.9.0",
+        "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -24,6 +25,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/lodash": "^4.17.13",
         "gh-pages": "^6.2.0"
       }
     },
@@ -4298,6 +4300,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "d3": "^7.9.0",
+    "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
@@ -46,6 +47,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.13",
     "gh-pages": "^6.2.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,6 +288,17 @@ function App() {
     } 
   };
 
+  const chartWaistCircumferenceVsBMI: any = useRef();
+
+  // Update Blood Measures vs. BMI when Physical Workout vs. Age exercise level bar selected.
+  const filterPointsWaistCircumferenceVsBMIOnExerciseLevelClick = (toggledExerciseLevelBar: boolean, group: any, subgroup: any) => {
+    if (chartWaistCircumferenceVsBMI.current !== undefined) {
+      let exerciseBarLevel: string = subgroup.key;
+      let ageGroup: string = group.data.x;
+      chartWaistCircumferenceVsBMI.current.onStackedBarExerciseBarClick(toggledExerciseLevelBar, ageGroup, exerciseBarLevel);
+    } 
+  };
+
   const chartRefAgeVsExercise: any = useRef();
 
   // Update Physical Workout vs. Age tooltip when Donut Gender chart slice is selected.
@@ -405,6 +416,7 @@ function App() {
                                 onExerciseLevelClick={[
                                   onStackedBarChartAgeVsExerciseClickExerciseLevel,
                                   filterPointsBloodMeasureVsBMIOnExerciseLevelClick,
+                                  filterPointsWaistCircumferenceVsBMIOnExerciseLevelClick,
                                   filterGenderDonutAfterExerciseLevelClick
                                 ]}
                                 onAgeGroupClick={[
@@ -428,6 +440,7 @@ function App() {
                               hoveredGroup={hoveredGroupDataWaistCircumferenceVsBMIByGender}
                               setHoveredGroup={setHoveredGroupDataWaistCircumferenceVsBMIByGender}
                               onPointClick={[]}
+                              ref={chartWaistCircumferenceVsBMI}
                             />
                         </div>
                     )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import StackedBarChartAgeVsExercise from "./components/charts/StackedBarChartAge
 // Import interactions
 import { onDonutChartGenderSliceClick } from "./interactions/InteractionsDonutChartGender";
 import { onScatterplotChartBloodMeasuresVsBMIClick } from "./interactions/InteractionsScatterplotChartBloodMeasuresVsBMI";
+import { onStackedBarChartAgeVsExerciseClick } from "./interactions/InteractionsStackedBarChartAgeVsExercise";
 
 // interface DataItemAgeVsExercise {
 //   Age: number;
@@ -225,7 +226,9 @@ function App() {
                   [ "insulin", parseFloat(participant["Insulin"]) ],
                   [ "glucoseAfter2Hour", parseFloat(participant["Lbxglt(Glucose after 2 hr)"]) ],
                   [ "glucoseFasting", parseFloat(participant["Lbxglu(Glucose fasting)"]) ],
-                  [ "markColorField", participant["Diabetes Diagnosis Status"] ] 
+                  [ "markColorField", participant["Diabetes Diagnosis Status"] ],
+                  [ "ageGroup", getAgeGroup(participant["Age"]) ],
+                  [ "exerciseLevel", participant["Paq605 ( Vigorous Exercise)"] ]
                 ]
               ) 
             })
@@ -246,7 +249,9 @@ function App() {
                   [ "waistCircumference", parseFloat(participant["Waist Circumference (cm)"])],
                   [ "bodyMassIndex", parseFloat(participant["Bmxbmi"]) ],
                   [ "markColorField", participant["Gender"] ],
-                  [ "filterGender", participant["Gender"] ]
+                  [ "filterGender", participant["Gender"] ],
+                  [ "ageGroup", getAgeGroup(participant["Age"]) ],
+                  [ "exerciseLevel", participant["Paq605 ( Vigorous Exercise)"] ]
                 ]
               ) 
             })
@@ -262,6 +267,17 @@ function App() {
     }
   }, []);
 
+
+  const chartBloodMeasuresVsBMI: any = useRef();
+
+  // Update Blood Measures vs. BMI when Physical Workout vs. Age exerciseLevel bar or age group is selected.
+  const filterPointsBloodMeasureVsBMI = (toggledExerciseLevelBar: boolean, group: any, subgroup: any) => {
+    if (chartBloodMeasuresVsBMI.current !== undefined) {
+      let exerciseBarLevel: string = subgroup.key;
+      let ageGroup: string = group.data.x;
+      chartBloodMeasuresVsBMI.current.onStackedBarExerciseBarClick(toggledExerciseLevelBar, ageGroup, exerciseBarLevel);
+    } 
+  };
 
   const chartRefAgeVsExercise: any = useRef();
 
@@ -321,6 +337,7 @@ function App() {
                                 hoveredGroup={hoveredGroupDataDataBloodMeasuresVsBMI}
                                 setHoveredGroup={setHoveredGroupDataDataBloodMeasuresVsBMI}
                                 onPointClick={[onScatterplotChartBloodMeasuresVsBMIClick]}
+                                ref={chartBloodMeasuresVsBMI}
                               />
                           </div>
                       )}
@@ -361,6 +378,11 @@ function App() {
                               <StackedBarChartAgeVsExercise
                                 height={328}
                                 data={barChartDataAgeVsExerciseLevel}
+                                onExerciseLevelClick={[
+                                  onStackedBarChartAgeVsExerciseClick,
+                                  filterPointsBloodMeasureVsBMI
+                                ]}
+                                onAgeGroupClick={[() => {}]}
                                 ref={chartRefAgeVsExercise}
                               />
                           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,7 +305,7 @@ function App() {
     }
   };
 
-  const filterGenderDonutAfterAgeGroupClick = (toggledAgeGroup: boolean, group: any, subgroup: any) => {
+  const filterGenderDonutAfterAgeGroupClick = (toggledAgeGroup: boolean, groupName: string, group: any) => {
     if (donutRefGender.current !== undefined) {
       donutRefGender.current.onUpdateGenderOnStackedBarAgeGroupClick(toggledAgeGroup, group);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,6 +299,13 @@ function App() {
     } 
   };
 
+  // Update Blood Measures vs. BMI when Physical Workout vs. Age age group selected.
+  const filterPointsWaistCircumferenceVsBMIOnAgeGroupClick = (toggledAgeGroup: boolean, ageGroup: string) => {
+    if (chartWaistCircumferenceVsBMI.current !== undefined) {
+      chartWaistCircumferenceVsBMI.current.onStackedBarAgeGroupClick(toggledAgeGroup, ageGroup);
+    } 
+  };
+  
   const chartRefAgeVsExercise: any = useRef();
 
   // Update Physical Workout vs. Age tooltip when Donut Gender chart slice is selected.
@@ -422,6 +429,7 @@ function App() {
                                 onAgeGroupClick={[
                                   onStackedBarChartAgeVsExerciseClickAgeGroup,
                                   filterPointsBloodMeasureVsBMIOnAgeGroupClick,
+                                  filterPointsWaistCircumferenceVsBMIOnAgeGroupClick,
                                   filterGenderDonutAfterAgeGroupClick
                                 ]}
                                 ref={chartRefAgeVsExercise}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,6 +262,16 @@ function App() {
     }
   }, []);
 
+
+  const chartRefAgeVsExercise: any = useRef();
+
+  // Update Physical Workout vs. Age tooltip when Donut Gender chart slice is selected.
+  const updateTooltipForPhysicalWorkoutVsAge = (toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>, sliceName: string) => {
+    if (chartRefAgeVsExercise.current !== undefined) {
+      chartRefAgeVsExercise.current.onDonutChartGenderSliceClick(toggledSlice, sliceName);
+    } 
+  };
+
   return (
     <div className="App">
         {isLoading && (
@@ -336,7 +346,10 @@ function App() {
                               data={donutChartDataGender}
                               onUpdateParticipantCount={setParticipantCount}
                               onFilterByGender={setHoveredGroupDataWaistCircumferenceVsBMIByGender}
-                              onSliceClick={[onDonutChartGenderSliceClick]}
+                              onSliceClick={[
+                                onDonutChartGenderSliceClick,
+                                updateTooltipForPhysicalWorkoutVsAge
+                              ]}
                             />
                         </div>
                       )}
@@ -348,6 +361,7 @@ function App() {
                               <StackedBarChartAgeVsExercise
                                 height={328}
                                 data={barChartDataAgeVsExerciseLevel}
+                                ref={chartRefAgeVsExercise}
                               />
                           </div>
                       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import StackedBarChartAgeVsExercise from "./components/charts/StackedBarChartAge
 // Import interactions
 import { onDonutChartGenderSliceClick } from "./interactions/InteractionsDonutChartGender";
 import { onScatterplotChartBloodMeasuresVsBMIClick } from "./interactions/InteractionsScatterplotChartBloodMeasuresVsBMI";
-import { onStackedBarChartAgeVsExerciseClick } from "./interactions/InteractionsStackedBarChartAgeVsExercise";
+import { onStackedBarChartAgeVsExerciseClickExerciseLevel, onStackedBarChartAgeVsExerciseClickAgeGroup } from "./interactions/InteractionsStackedBarChartAgeVsExercise";
 
 // interface DataItemAgeVsExercise {
 //   Age: number;
@@ -270,12 +270,19 @@ function App() {
 
   const chartBloodMeasuresVsBMI: any = useRef();
 
-  // Update Blood Measures vs. BMI when Physical Workout vs. Age exerciseLevel bar or age group is selected.
-  const filterPointsBloodMeasureVsBMI = (toggledExerciseLevelBar: boolean, group: any, subgroup: any) => {
+  // Update Blood Measures vs. BMI when Physical Workout vs. Age exercise level bar selected.
+  const filterPointsBloodMeasureVsBMIOnExerciseLevelClick = (toggledExerciseLevelBar: boolean, group: any, subgroup: any) => {
     if (chartBloodMeasuresVsBMI.current !== undefined) {
       let exerciseBarLevel: string = subgroup.key;
       let ageGroup: string = group.data.x;
       chartBloodMeasuresVsBMI.current.onStackedBarExerciseBarClick(toggledExerciseLevelBar, ageGroup, exerciseBarLevel);
+    } 
+  };
+
+  // Update Blood Measures vs. BMI when Physical Workout vs. Age age group selected.
+  const filterPointsBloodMeasureVsBMIOnAgeGroupClick = (toggledAgeGroup: boolean, ageGroup: string) => {
+    if (chartBloodMeasuresVsBMI.current !== undefined) {
+      chartBloodMeasuresVsBMI.current.onStackedBarAgeGroupClick(toggledAgeGroup, ageGroup);
     } 
   };
 
@@ -379,10 +386,14 @@ function App() {
                                 height={328}
                                 data={barChartDataAgeVsExerciseLevel}
                                 onExerciseLevelClick={[
-                                  onStackedBarChartAgeVsExerciseClick,
-                                  filterPointsBloodMeasureVsBMI
+                                  onStackedBarChartAgeVsExerciseClickAgeGroup,
+                                  onStackedBarChartAgeVsExerciseClickExerciseLevel,
+                                  filterPointsBloodMeasureVsBMIOnExerciseLevelClick
                                 ]}
-                                onAgeGroupClick={[() => {}]}
+                                onAgeGroupClick={[
+                                  onStackedBarChartAgeVsExerciseClickAgeGroup,
+                                  filterPointsBloodMeasureVsBMIOnAgeGroupClick
+                                ]}
                                 ref={chartRefAgeVsExercise}
                               />
                           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@
 // https://www.geeksforgeeks.org/how-to-skip-over-an-element-in-map/
 
 import { useEffect, useRef, useState } from "react";
+import * as _ from "lodash";
+
 import logo from './logo.svg';
 import './App.css';
 
@@ -295,6 +297,20 @@ function App() {
     } 
   };
 
+  const donutRefGender: any = useRef();
+
+  const filterGenderDonutAfterExerciseLevelClick = (toggledExerciseLevelBar: boolean, group: any, subgroup: any) => {
+    if (donutRefGender.current !== undefined) {
+      donutRefGender.current.onUpdateGenderOnStackedBarExerciseBarClick(toggledExerciseLevelBar, group, subgroup);
+    }
+  };
+
+  const filterGenderDonutAfterAgeGroupClick = (toggledAgeGroup: boolean, group: any, subgroup: any) => {
+    if (donutRefGender.current !== undefined) {
+      donutRefGender.current.onUpdateGenderOnStackedBarAgeGroupClick(toggledAgeGroup, group);
+    }
+  };
+
   return (
     <div className="App">
         {isLoading && (
@@ -374,6 +390,7 @@ function App() {
                                 onDonutChartGenderSliceClick,
                                 updateTooltipForPhysicalWorkoutVsAge
                               ]}
+                              ref={donutRefGender}
                             />
                         </div>
                       )}
@@ -386,13 +403,14 @@ function App() {
                                 height={328}
                                 data={barChartDataAgeVsExerciseLevel}
                                 onExerciseLevelClick={[
-                                  onStackedBarChartAgeVsExerciseClickAgeGroup,
                                   onStackedBarChartAgeVsExerciseClickExerciseLevel,
-                                  filterPointsBloodMeasureVsBMIOnExerciseLevelClick
+                                  filterPointsBloodMeasureVsBMIOnExerciseLevelClick,
+                                  filterGenderDonutAfterExerciseLevelClick
                                 ]}
                                 onAgeGroupClick={[
                                   onStackedBarChartAgeVsExerciseClickAgeGroup,
-                                  filterPointsBloodMeasureVsBMIOnAgeGroupClick
+                                  filterPointsBloodMeasureVsBMIOnAgeGroupClick,
+                                  filterGenderDonutAfterAgeGroupClick
                                 ]}
                                 ref={chartRefAgeVsExercise}
                               />

--- a/src/components/axis/AxisLeftCategoric.tsx
+++ b/src/components/axis/AxisLeftCategoric.tsx
@@ -1,23 +1,39 @@
 // @ts-nocheck
-import { useMemo, useState } from 'react';
-import { ScaleBand } from 'd3';
+import { forwardRef, useImperativeHandle, useMemo, useState } from 'react';
+// import { ScaleBand } from 'd3';
+import * as d3 from "d3";
 
-type AxisLeftProps = {
+interface AxisLeftProps {
   yScale: ScaleBand<string>;
+  onLabelClick?: Array<Function> | [];
+};
+
+interface AxisLeftPropsRef {
+  onDonutChartGenderSliceClick: (d: any) => void;
 };
 
 // tick length
 const TICK_LENGTH = 6;
 
-export const AxisLeft = ({ yScale }: AxisLeftProps) => {
-  const [min, max] = yScale.range();
+export const AxisLeft = forwardRef<AxisLeftPropsRef, AxisLeftProps>((props, ref) => {
+  
+  const [toggledAxisLabel, setToggledAxisLabel] = useState(false);
+
+  const [min, max] = props.yScale.range();
 
   const ticks = useMemo(() => {
-    return yScale.domain().map((value: any) => ({
+    return props.yScale.domain().map((value: any) => ({
       value,
-      yOffset: yScale(value) + yScale.bandwidth() / 2,
+      yOffset: props.yScale(value) + props.yScale.bandwidth() / 2,
     }));
-  }, [yScale]);
+  }, [props.yScale]);
+
+  useImperativeHandle(ref, () => ({
+      // @ts-ignore
+      toggleAxisLabel(toggledSelection: boolean) {
+          setToggledAxisLabel(toggledSelection);
+      },
+  }));  
 
   // d={["M", range[0], 0, "L", range[1], 0].join(" ")}
   return (
@@ -39,8 +55,42 @@ export const AxisLeft = ({ yScale }: AxisLeftProps) => {
               fontSize: '12px',
               textAnchor: 'end',
               alignmentBaseline: 'middle',
-              transform: 'translateX(-10px)'
+              transform: 'translateX(-10px)',
+              cursor: 'pointer'
             }}
+            onClick={(x) => {
+              setToggledAxisLabel(!toggledAxisLabel);
+              // console.log("AxisLeftCategoric selected", !toggledAxisLabel);
+                
+              if (!toggledAxisLabel) {
+                  // Change style for the selected label.
+                  x.currentTarget.style.fontWeight = 'bold';
+                  x.currentTarget.style.fontSize = '14px';
+                  d3
+                  .select(x.currentTarget)
+                    .attr('fill', '#399D3E');
+
+                  // Enable the currently selected axis label.
+                  x.currentTarget.setAttribute("data-selected-axis-label", "true");
+              } else {
+                  // Disable all previously selected labels.
+                  d3
+                  .select(x.currentTarget.parentElement?.parentElement)
+                  .selectAll("[data-selected-axis-label='true']")
+                    .attr('fill', 'black')
+                    .style('font-weight', 'normal')
+                    .style('font-size', '12px');
+
+                  // Disable the currently selected axis label.
+                  x.currentTarget.setAttribute("data-selected-axis-label", "false");
+              }
+
+              // Call all functions passed into label click parameter.
+              props.onLabelClick?.forEach((func) => {
+                func(x.currentTarget.textContent);
+              });
+          }}
+          data-selected-axis-label={false}
           >
             {value}
           </text>
@@ -48,4 +98,4 @@ export const AxisLeft = ({ yScale }: AxisLeftProps) => {
       ))}
     </>
   );
-};
+});

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -27,7 +27,7 @@ const INFLEXION_PADDING = 20; // space between donut and label inflexion point
 
 const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, onUpdateParticipantCount, onFilterByGender, onSliceClick }: D3DonutChartProps) => {
     const [participantCount, setParticipantCount] = useState(0);
-    const [toggledSlice, setToggledSlice] = useState(false);
+    let [toggledSlice, setToggledSlice] = useState(false);
     
     const ref = useRef<SVGGElement>(null);
     const refParent = useRef<HTMLDivElement>(null); // Todo: Need to revisit this on responsive sizing.
@@ -87,7 +87,11 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
             }}
             onClick={(s) => {
                 // console.log("toggledSlice = " + toggledSlice);
+                
                 setToggledSlice(!toggledSlice);
+                // Need to ensure that the toggledSlice gets applied in this onClick event.
+                // Typically the setToggledSlice useState setter update will only be applied in a useEffect call.
+                toggledSlice = !toggledSlice;
 
                 // Handle interactions passed for slice click for other charts.
                 onSliceClick.forEach((func) => {

--- a/src/components/charts/D3DonutChart.tsx
+++ b/src/components/charts/D3DonutChart.tsx
@@ -13,6 +13,8 @@ type D3DonutChartProps = {
   width: number;
   height: number;
   data: DataItem[];
+  dataOriginal?: DataItem[];
+  dataFiltered?: DataItem[];
   showPercentages: boolean;
   markColorScale: d3.ScaleOrdinal<any, any>;
   onUpdateParticipantCount: Function;
@@ -98,6 +100,12 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                     func(toggledSlice, grp.data.seqnIdentifiers, grp.data.name);
                 });
 
+                // Remove all existing inline styling for all slices previously selected. Also remove data attribute signifying selected slice.
+                document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice) => {
+                    slice.removeAttribute("style");
+                    slice.removeAttribute("data-gender-slice-selected");
+                });
+
                 if (toggledSlice) {
                     
                     // Change the number for participants based on the slice selection.
@@ -108,15 +116,11 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                     if (ref.current) {
                         ref.current.classList.add(styles.hasHighlight);
                     }
-
-                    // Remove all existing inline styling for all slices previously selected.
-                    document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice) => {
-                        slice.removeAttribute("style");
-                    });
                     
-                    // Add an inline styling for current selected slice.
+                    // Add an inline styling for current selected slice and add data for slice selected.
                     d3.select(s.currentTarget)
-                    .attr("style", "filter: saturate(100%); opacity: 1;");
+                    .attr("style", "filter: saturate(100%); opacity: 1;")
+                    .attr("data-gender-slice-selected", grp.data.name);
 
                     if (onFilterByGender !== undefined) {
                         onFilterByGender(grp.data.name);
@@ -136,9 +140,10 @@ const D3DonutChart = ({ width, height, data, showPercentages, markColorScale, on
                         ref.current.classList.remove(styles.hasHighlight);
                     }
 
-                    // Remove inline style for current selected slice.
-                    d3.select(s.currentTarget)
-                    .attr("style", null);
+                    // Remove inline style for current selected slice and data selected attribute.
+                    // d3.select(s.currentTarget)
+                    // .attr("style", null)
+                    // .attr("data-gender-slice-selected", null);
 
                     if (onFilterByGender !== undefined) {
                         onFilterByGender(null);

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -26,7 +26,7 @@ let MARGIN: {
         left: 70 
     };
 
-type D3ScatterplotChartProps = {
+interface D3ScatterplotChartProps {
     height: number;
     data: { 
         x: number;
@@ -79,22 +79,24 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
     // @ts-expect-error
     const width = dms.width;
     
-    // Create the horizontal scale and its axis generator.
     const xScale = d3
-    .scaleLinear()
+    .scaleLog()
     .domain([
-        (d3.min(data, (d) => d.x) as number) - 1,
+        Math.max(0.1, (d3.min(data, (d) => d.x) as number) - 1), // Ensure the minimum value > 0
         (d3.max(data, (d) => d.x) as number) + 5
     ]) // data points for x
+    // .nice()
     .range([0, boundsWidth]); // axis x dimensions
 
     const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
 
-    // Create the vertical scale and its axis generator.
     const yScale = d3
-    .scaleLinear()
-    .domain([0, (d3.max(data, (d) => d.y) as number) + 5]) // data points for y
-    .nice()
+    .scaleLog()
+    .domain([
+        Math.max(0.1, (d3.min(data, (d) => d.y) as number) - 1), // Ensure the minimum value > 0
+        (d3.max(data, (d) => d.y) as number) + 5
+    ]) // data points for y
+    // .nice()
     .range([boundsHeight, 0]); // axis y dimensions
 
     const yAxis = d3.axisLeft(yScale);
@@ -118,7 +120,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
           fill={markColorScale(d.markColorField)}
           fillOpacity={0.6}
           onMouseOver={() => {
-            setHoveredGroup(d.markColorField);
+            // setHoveredGroup(d.markColorField);
             setHovered({
                 xPos: xScale(d.x),
                 yPos: yScale(d.y),
@@ -132,7 +134,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
               });
           }}
           onMouseLeave={() => { 
-            setHoveredGroup(null)
+            // setHoveredGroup(null)
             setHovered(null)
           }}
           onClick={(x) => {

--- a/src/components/charts/D3ScatterplotChart.tsx
+++ b/src/components/charts/D3ScatterplotChart.tsx
@@ -11,6 +11,7 @@ import useChartDimensions from "../../hooks/useChartDimensions";
 import { StripGenerator } from "./StripGenerator";
 import { AxisBottom } from "../axis/AxisBottom";
 import { AxisLeft } from "../axis/AxisLeft";
+import { CircleShape } from "../marks/Shape";
 import { InteractionData, Tooltip } from "../marks/Tooltip";
 import { Swatches } from "../legend/Swatches";
 
@@ -30,7 +31,11 @@ interface D3ScatterplotChartProps {
     height: number;
     data: { 
         x: number;
+        xScaleMin?: number | undefined;
+        xScaleMax?: number | undefined;
         y: number;
+        yScaleMin?: number | undefined;
+        yScaleMax?: number | undefined;
         markColorField: string;
         filterGender: string;
         seqn: number;
@@ -79,28 +84,32 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
     // @ts-expect-error
     const width = dms.width;
     
+    const xScaleMinValue:number = data[0]?.xScaleMin || Math.max(0.1, (d3.min(data, (d) => d.x) as number) - 1);
+    const xScaleMaxValue:number = data[0]?.xScaleMax || (d3.max(data, (d) => d.x) as number) + 5;
     const xScale = d3
     .scaleLog()
     .domain([
-        Math.max(0.1, (d3.min(data, (d) => d.x) as number) - 1), // Ensure the minimum value > 0
-        (d3.max(data, (d) => d.x) as number) + 5
+        xScaleMinValue, // Ensure the minimum value > 0
+        xScaleMaxValue
     ]) // data points for x
     // .nice()
     .range([0, boundsWidth]); // axis x dimensions
 
     const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
 
+    const yScaleMinValue:number = data[0]?.yScaleMin || Math.max(0.1, (d3.min(data, (d) => d.y) as number) - 1);
+    const yScaleMaxValue:number = data[0]?.yScaleMax || (d3.max(data, (d) => d.y) as number) + 5;
     const yScale = d3
     .scaleLog()
     .domain([
-        Math.max(0.1, (d3.min(data, (d) => d.y) as number) - 1), // Ensure the minimum value > 0
-        (d3.max(data, (d) => d.y) as number) + 5
+        yScaleMinValue, // Ensure the minimum value > 0
+        yScaleMaxValue
     ]) // data points for y
     // .nice()
     .range([boundsHeight, 0]); // axis y dimensions
 
     const yAxis = d3.axisLeft(yScale);
-
+    
     // Build the shapes (dots)
     const allShapes = data.map((d, i) => {
 
@@ -112,7 +121,8 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
       return (
         <circle
           key={i}
-          r={5}
+          // @ts-ignore
+          r={CircleShape.radius}
           cx={xScale(d.x)}
           cy={yScale(d.y)}
           className={className}
@@ -147,7 +157,7 @@ const D3ScatterplotChart = ({ height, data, markColorFieldLegendName, markColorS
 
           }}
           data-seqn={d.seqn}
-        />
+        />        
       );
     });
 

--- a/src/components/charts/D3StackedBarChart.tsx
+++ b/src/components/charts/D3StackedBarChart.tsx
@@ -259,7 +259,8 @@ const D3StackedBarChart = forwardRef<D3StackedBarChartRef, D3StackedBarplotChart
         }
 
         props.onGroupClick?.forEach((func) => {
-            func(!toggledBarGroup, groupName);
+            let group = props.data.filter((d) => d.x === groupName);
+            func(!toggledBarGroup, groupName, group[0]);
         });
     }
 

--- a/src/components/charts/DonutChartGender.tsx
+++ b/src/components/charts/DonutChartGender.tsx
@@ -1,5 +1,9 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
 
+import * as _ from "lodash";
 import * as d3 from "d3";
+
+import styles from "./donut-chart.module.css";
 
 import D3DonutChart from "./D3DonutChart";
 import { colorScaleGender } from "../marks/Color";
@@ -11,7 +15,7 @@ type DataItem = {
     percentage: number;
   };
 
-type DonutChartGenderProps = {
+interface DonutChartGenderProps {
     width: number;
     height: number;
     data: DataItem[];
@@ -20,22 +24,114 @@ type DonutChartGenderProps = {
     onSliceClick: Array<Function> | [];
 };
 
-const DonutChartGender = ({ width, height, data, onUpdateParticipantCount, onFilterByGender, onSliceClick }: DonutChartGenderProps) => {
+interface DonutChartGenderRef {
+    onUpdateGenderOnStackedBarExerciseBarClick: (d: any) => void;
+};
+
+const DonutChartGender = forwardRef<DonutChartGenderRef, DonutChartGenderProps>((props, ref) => {
+
+    const [filteredGenderDonutChartData, setFilteredGenderDonutChartData] = useState<Array<DataItem>>(_.cloneDeep(props.data));
+    // setGenderDonutChartData(_.cloneDeep(props.data));
+    // const [genderDonutChartDataOriginal, setGenderDonutChartDataOriginal] = useState(props.dataOriginal);
+    // const [genderDonutChartDataFiltered, setGenderDonutChartDataFiltered] = useState(props.data);
+
+    useImperativeHandle(ref, () => ({
+
+        // @ts-ignore
+        onUpdateGenderOnStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: any, exerciseLevel: any) {
+            console.log("Donut updateGenderExerciseClick", toggledExerciseLevelBar, ageGroup, exerciseLevel);
+
+            let dataExerciseLevel = 0;
+            let dataExerciseLevelMale = 0;
+            let dataExerciseLevelFemale = 0;
+
+            if (exerciseLevel.key === "No") {
+                dataExerciseLevel = ageGroup.data.No
+                dataExerciseLevelMale = ageGroup.data.NoMale;
+                dataExerciseLevelFemale = ageGroup.data.NoFemale;
+            } else if (exerciseLevel.key === "Vigorous") {
+                dataExerciseLevel = ageGroup.data.Vigorous
+                dataExerciseLevelMale = ageGroup.data.VigorousMale;
+                dataExerciseLevelFemale = ageGroup.data.VigorousFemale;
+            }
+
+            let filteredDonutChartData:Array<DataItem> = _.cloneDeep(props.data);
+
+            if (toggledExerciseLevelBar) {
+                filteredDonutChartData.forEach((d) => {
+                    switch (d.name) {
+                        case "Female":
+                            d.value = dataExerciseLevelFemale;
+                            d.percentage = (dataExerciseLevelFemale / dataExerciseLevel) * 100;
+                            break;
+                        case "Male":
+                            d.value = dataExerciseLevelMale;
+                            d.percentage = (dataExerciseLevelMale / dataExerciseLevel) * 100
+                            break;
+                    }
+                });
+
+                setFilteredGenderDonutChartData(filteredDonutChartData);
+            } else {
+                let selectedGenderSlice:string | null = "";
+                document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice: any) => {
+                    if (slice.dataset.genderSliceSelected !== undefined) {
+                        selectedGenderSlice = slice.dataset.genderSliceSelected;
+
+                        slice.removeAttribute("style");
+                        slice.setAttribute("style", "filter: saturate(100%); opacity: 1;");
+                        slice.setAttribute("data-gender-slice-selected", slice.dataset.genderSliceSelected);
+                    } else {
+                        slice.removeAttribute("style");
+                        slice.removeAttribute("data-gender-slice-selected");
+
+                    }
+                });
+
+                setFilteredGenderDonutChartData(filteredDonutChartData);
+            }
+
+            // Update participant count based on slice selection.
+            let totalParticipantCountSelectedSlice = 0;
+            document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice: any) => {
+                const sliceGenderSelected = filteredDonutChartData.filter((d) => d.name === slice.dataset.genderSliceSelected);
+                var sliceValue = (sliceGenderSelected.length !== 0 ? sliceGenderSelected[0].value : 0 );
+                if (slice.dataset.genderSliceSelected !== undefined) {
+                    totalParticipantCountSelectedSlice += sliceValue;
+                }
+            });
+
+            // Change the number for participants for the whole donut chart values.
+            let totalParticipantCountAllSlices = 0;
+            filteredDonutChartData.forEach((slice) => {
+                totalParticipantCountAllSlices += slice.value
+            })
+
+            props.onUpdateParticipantCount(
+                totalParticipantCountSelectedSlice !== 0 ? totalParticipantCountSelectedSlice : 
+                totalParticipantCountAllSlices
+            );
+        },
+        onUpdateGenderOnStackedBarAgeGroupClick(toggledAgeGroup: boolean, ageGroup: any) {
+            console.log("Donut updateGenderAgeGroupClick", toggledAgeGroup, ageGroup);
+        }
+    }));
 
     return (
         <>
         <D3DonutChart
-            width={width}
-            height={height}
-            data={data}
+            width={props.width}
+            height={props.height}
+            data={filteredGenderDonutChartData}
+            // dataOriginal={props.dataOriginal}
             showPercentages={true}
             markColorScale={colorScaleGender}
-            onUpdateParticipantCount={onUpdateParticipantCount}
-            onFilterByGender={onFilterByGender}
-            onSliceClick={onSliceClick}
+            onUpdateParticipantCount={props.onUpdateParticipantCount}
+            onFilterByGender={props.onFilterByGender}
+            onSliceClick={props.onSliceClick}
         />
         </>
     );
-};
+});
 
 export default DonutChartGender;

--- a/src/components/charts/DonutChartGender.tsx
+++ b/src/components/charts/DonutChartGender.tsx
@@ -39,11 +39,12 @@ const DonutChartGender = forwardRef<DonutChartGenderRef, DonutChartGenderProps>(
 
         // @ts-ignore
         onUpdateGenderOnStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: any, exerciseLevel: any) {
-            console.log("Donut updateGenderExerciseClick", toggledExerciseLevelBar, ageGroup, exerciseLevel);
+            // console.log("Donut updateGenderExerciseClick", toggledExerciseLevelBar, ageGroup, exerciseLevel);
 
-            let dataExerciseLevel = 0;
-            let dataExerciseLevelMale = 0;
-            let dataExerciseLevelFemale = 0;
+            // Calculate the age group values and percentages filtered by gender.
+            let dataExerciseLevel:number = 0;
+            let dataExerciseLevelMale:number = 0;
+            let dataExerciseLevelFemale:number = 0;
 
             if (exerciseLevel.key === "No") {
                 dataExerciseLevel = ageGroup.data.No
@@ -73,6 +74,7 @@ const DonutChartGender = forwardRef<DonutChartGenderRef, DonutChartGenderProps>(
 
                 setFilteredGenderDonutChartData(filteredDonutChartData);
             } else {
+                // Disable slices that are not selected and enable ones that were previous selected.
                 let selectedGenderSlice:string | null = "";
                 document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice: any) => {
                     if (slice.dataset.genderSliceSelected !== undefined) {
@@ -114,6 +116,73 @@ const DonutChartGender = forwardRef<DonutChartGenderRef, DonutChartGenderProps>(
         },
         onUpdateGenderOnStackedBarAgeGroupClick(toggledAgeGroup: boolean, ageGroup: any) {
             console.log("Donut updateGenderAgeGroupClick", toggledAgeGroup, ageGroup);
+
+            // Calculate the age group values and percentages filtered by gender.
+            let dataAgeGroup:number = 0;
+            let dataAgeGroupMale:number = 0;
+            let dataAgeGroupFemale:number = 0;
+
+            dataAgeGroup = ageGroup.No + ageGroup.Vigorous;
+            dataAgeGroupMale = ageGroup.NoMale + ageGroup.VigorousMale;
+            dataAgeGroupFemale = ageGroup.NoFemale + ageGroup.VigorousFemale;
+                    
+            let filteredDonutChartData:Array<DataItem> = _.cloneDeep(props.data);
+
+            if (toggledAgeGroup) {
+                filteredDonutChartData.forEach((d) => {
+                    switch (d.name) {
+                        case "Female":
+                            d.value = dataAgeGroupFemale;
+                            d.percentage = (dataAgeGroupFemale / dataAgeGroup) * 100;
+                            break;
+                        case "Male":
+                            d.value = dataAgeGroupMale;
+                            d.percentage = (dataAgeGroupMale / dataAgeGroup) * 100
+                            break;
+                    }
+                });
+
+                setFilteredGenderDonutChartData(filteredDonutChartData);
+            } else {
+                // Disable slices that are not selected and enable ones that were previous selected.
+                let selectedGenderSlice:string | null = "";
+                document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice: any) => {
+                    if (slice.dataset.genderSliceSelected !== undefined) {
+                        selectedGenderSlice = slice.dataset.genderSliceSelected;
+
+                        slice.removeAttribute("style");
+                        slice.setAttribute("style", "filter: saturate(100%); opacity: 1;");
+                        slice.setAttribute("data-gender-slice-selected", slice.dataset.genderSliceSelected);
+                    } else {
+                        slice.removeAttribute("style");
+                        slice.removeAttribute("data-gender-slice-selected");
+
+                    }
+                });
+
+                setFilteredGenderDonutChartData(filteredDonutChartData);
+            }
+
+            // Update participant count based on slice selection.
+            let totalParticipantCountSelectedSlice = 0;
+            document.querySelectorAll('[class^="donut-chart_slice"]').forEach((slice: any) => {
+                const sliceGenderSelected = filteredDonutChartData.filter((d) => d.name === slice.dataset.genderSliceSelected);
+                var sliceValue = (sliceGenderSelected.length !== 0 ? sliceGenderSelected[0].value : 0 );
+                if (slice.dataset.genderSliceSelected !== undefined) {
+                    totalParticipantCountSelectedSlice += sliceValue;
+                }
+            });
+
+            // Change the number for participants for the whole donut chart values.
+            let totalParticipantCountAllSlices = 0;
+            filteredDonutChartData.forEach((slice) => {
+                totalParticipantCountAllSlices += slice.value
+            })
+
+            props.onUpdateParticipantCount(
+                totalParticipantCountSelectedSlice !== 0 ? totalParticipantCountSelectedSlice : 
+                totalParticipantCountAllSlices
+            );
         }
     }));
 

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -1,10 +1,11 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
 
 import * as d3 from "d3";
 
 import D3ScatterPlotChart from "./D3ScatterplotChart";
 import { colorScaleGender, colorScaleDiabetesDiagnosisStatus } from "../marks/Color";
 
-type ScatterplotChartBloodMeasuresVsBMIProps = {
+interface ScatterplotChartBloodMeasuresVsBMIProps {
     height: number;
     data: { 
         seqn: number;
@@ -14,17 +15,23 @@ type ScatterplotChartBloodMeasuresVsBMIProps = {
         bodyMassIndex: number;
         markColorField: string;
         filterGender: string;
+        ageGroup: string,
+        exerciseLevel: string;
     }[];
     hoveredGroup: string | null;
     setHoveredGroup: Function;
     onPointClick: Array<Function> | [];
 };
 
-const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHoveredGroup, onPointClick }: ScatterplotChartBloodMeasuresVsBMIProps) => {
+interface ScatterplotChartBloodMeasuresVsBMIRef {
+    onStackedBarExerciseBarClick: (d: any) => void;
+};
+  
+const ScatterplotChartBloodMeasuresVsBMI =forwardRef<ScatterplotChartBloodMeasuresVsBMIRef, ScatterplotChartBloodMeasuresVsBMIProps>((props, ref) => {
 
     // data.map(d => console.log(d));
 
-    const scatterplotChartDataGlucoseFastingvsBMI = d3.map(data, (d) => {
+    const [scatterplotChartDataGlucoseFastingvsBMI, setScatterplotChartDataGlucoseFastingvsBMI] = useState<any>(d3.map(props.data, (d) => {
         return {
             x: d.bodyMassIndex,
             y: d.glucoseFasting,
@@ -32,9 +39,9 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             filterGender: d.filterGender,
             seqn: d.seqn
         }
-    });
+    }));
 
-    const scatterplotChartDataGluscoseAfter2HourvsBMI = d3.map(data, (d) => {
+    const [scatterplotChartDataGluscoseAfter2HourvsBMI, setScatterplotChartDataGluscoseAfter2HourvsBMI] = useState<any>(d3.map(props.data, (d) => {
         return {
             x: d.bodyMassIndex,
             y: d.glucoseAfter2Hour,
@@ -42,9 +49,9 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             filterGender: d.filterGender,
             seqn: d.seqn
         }
-    });
+    }));
 
-    const scatterplotChartDataInsulinvsBMI = d3.map(data, (d) => {
+    const [scatterplotChartDataInsulinvsBMI, setScatterplotChartDataInsulinvsBMI] = useState<any>(d3.map(props.data, (d) => {
         return {
             x: d.bodyMassIndex,
             y: d.insulin,
@@ -52,12 +59,90 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             filterGender: d.filterGender,
             seqn: d.seqn
         }
-    });
+    }));
+
+    useImperativeHandle(ref, () => ({
+        // @ts-ignore
+        onStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: string, exerciseBarLevel: string) {
+            // console.log("onStackedBarExerciseBarClick", ageGroup, exerciseBarLevel);
+            if (toggledExerciseLevelBar) {
+
+                // Filter original values by ageGroup and exercise level and re-render.
+                const filteredData = props.data.filter((d) => 
+                    d.ageGroup === ageGroup && 
+                    d.exerciseLevel.trim().toLowerCase() === exerciseBarLevel.trim().toLowerCase()
+                );
+
+                setScatterplotChartDataGlucoseFastingvsBMI(d3.map(filteredData, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.glucoseFasting,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+
+                setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(filteredData, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.glucoseAfter2Hour,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+
+                setScatterplotChartDataInsulinvsBMI(d3.map(filteredData, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.insulin,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+            } else {
+
+                // Reset data back to original values and re-render.
+                setScatterplotChartDataGlucoseFastingvsBMI(d3.map(props.data, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.glucoseFasting,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+
+                setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(props.data, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.glucoseAfter2Hour,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+
+                setScatterplotChartDataInsulinvsBMI(d3.map(props.data, (d) => {
+                    return {
+                        x: d.bodyMassIndex,
+                        y: d.insulin,
+                        markColorField: d.markColorField,
+                        filterGender: d.filterGender,
+                        seqn: d.seqn
+                    }
+                }));
+            }
+                     
+        },
+    }));  
 
     return (
         <>
         <D3ScatterPlotChart
-            height={height}
+            height={props.height}
             data={scatterplotChartDataGlucoseFastingvsBMI}
             markColorScale={colorScaleDiabetesDiagnosisStatus}
             markColorFieldLegendName="Diabetes Status"
@@ -65,13 +150,14 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             yAxisLabel="Fasting Blood Glucose"
             yAxisTicks={8}
             showXAxis={false}
-            hoveredGroup={hoveredGroup}
-            setHoveredGroup={setHoveredGroup}
+            // legendAlign="left"
+            hoveredGroup={props.hoveredGroup}
+            setHoveredGroup={props.setHoveredGroup}
             interactiveClassName={"chart-1"}
-            onPointClick={onPointClick}
+            onPointClick={props.onPointClick}
         />
         <D3ScatterPlotChart
-            height={height}
+            height={props.height}
             data={scatterplotChartDataGluscoseAfter2HourvsBMI}
             markColorScale={colorScaleDiabetesDiagnosisStatus}
             markColorFieldLegendName="Diabetes Status"
@@ -80,13 +166,13 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             yAxisTicks={12}
             showXAxis={false}
             showLegend={false}
-            hoveredGroup={hoveredGroup}
-            setHoveredGroup={setHoveredGroup}
+            hoveredGroup={props.hoveredGroup}
+            setHoveredGroup={props.setHoveredGroup}
             interactiveClassName={"chart-2"}
-            onPointClick={onPointClick}
+            onPointClick={props.onPointClick}
         />
         <D3ScatterPlotChart
-            height={height+70}
+            height={props.height+70}
             data={scatterplotChartDataInsulinvsBMI}
             markColorScale={colorScaleDiabetesDiagnosisStatus}
             markColorFieldLegendName="Diabetes Status"
@@ -95,13 +181,13 @@ const ScatterplotChartBloodMeasuresVsBMI = ({ height, data, hoveredGroup, setHov
             xAxisTicks={13}
             yAxisTicks={10}
             showLegend={false}
-            hoveredGroup={hoveredGroup}
-            setHoveredGroup={setHoveredGroup}
+            hoveredGroup={props.hoveredGroup}
+            setHoveredGroup={props.setHoveredGroup}
             interactiveClassName={"chart-3"}
-            onPointClick={onPointClick}
+            onPointClick={props.onPointClick}
         />
         </>
     );
-};
+});
 
 export default ScatterplotChartBloodMeasuresVsBMI;

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -15,7 +15,7 @@ interface ScatterplotChartBloodMeasuresVsBMIProps {
         bodyMassIndex: number;
         markColorField: string;
         filterGender: string;
-        ageGroup: string,
+        ageGroup: string;
         exerciseLevel: string;
     }[];
     hoveredGroup: string | null;
@@ -124,7 +124,7 @@ const ScatterplotChartBloodMeasuresVsBMI =forwardRef<ScatterplotChartBloodMeasur
         },
         // @ts-ignore
         onStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: string, exerciseBarLevel: string) {
-            // console.log("onStackedBarExerciseBarClick", ageGroup, exerciseBarLevel);
+            // console.log("onStackedBarExerciseBarClick", toggledExerciseLevelBar, ageGroup, exerciseBarLevel);
 
             let filteredData:Array<any> = [];
 

--- a/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartBloodMeasuresVsBMI.tsx
@@ -62,80 +62,126 @@ const ScatterplotChartBloodMeasuresVsBMI =forwardRef<ScatterplotChartBloodMeasur
     }));
 
     useImperativeHandle(ref, () => ({
+
+        onStackedBarAgeGroupClick(toggledAgeGroup: boolean, ageGroup: string) {
+            // console.log("onStackedBarAgeGroupClick", toggledAgeGroup, ageGroup);
+
+            let filteredData:Array<any> = [];
+
+            if (toggledAgeGroup) {
+                // Filter original values by ageGroup and exercise level and re-render.
+                filteredData = props.data.filter((d) => 
+                    d.ageGroup === ageGroup
+                );
+
+            } else {
+                // Reset data back to original values and re-render.
+                filteredData = props.data;
+            }
+
+            // Render the charts with filtered data.
+            setScatterplotChartDataGlucoseFastingvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.glucoseFasting,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.glucoseFasting) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.glucoseFasting) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+
+            setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0,
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.glucoseAfter2Hour,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.glucoseAfter2Hour) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.glucoseAfter2Hour) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+
+            setScatterplotChartDataInsulinvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.insulin,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.insulin) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.insulin) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+        },
         // @ts-ignore
         onStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: string, exerciseBarLevel: string) {
             // console.log("onStackedBarExerciseBarClick", ageGroup, exerciseBarLevel);
+
+            let filteredData:Array<any> = [];
+
             if (toggledExerciseLevelBar) {
 
                 // Filter original values by ageGroup and exercise level and re-render.
-                const filteredData = props.data.filter((d) => 
+                filteredData = props.data.filter((d) => 
                     d.ageGroup === ageGroup && 
                     d.exerciseLevel.trim().toLowerCase() === exerciseBarLevel.trim().toLowerCase()
                 );
-
-                setScatterplotChartDataGlucoseFastingvsBMI(d3.map(filteredData, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.glucoseFasting,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
-
-                setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(filteredData, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.glucoseAfter2Hour,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
-
-                setScatterplotChartDataInsulinvsBMI(d3.map(filteredData, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.insulin,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
             } else {
 
                 // Reset data back to original values and re-render.
-                setScatterplotChartDataGlucoseFastingvsBMI(d3.map(props.data, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.glucoseFasting,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
-
-                setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(props.data, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.glucoseAfter2Hour,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
-
-                setScatterplotChartDataInsulinvsBMI(d3.map(props.data, (d) => {
-                    return {
-                        x: d.bodyMassIndex,
-                        y: d.insulin,
-                        markColorField: d.markColorField,
-                        filterGender: d.filterGender,
-                        seqn: d.seqn
-                    }
-                }));
+                filteredData = props.data;
             }
-                     
+            
+            setScatterplotChartDataGlucoseFastingvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.glucoseFasting,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.glucoseFasting) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.glucoseFasting) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+
+            setScatterplotChartDataGluscoseAfter2HourvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0,
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.glucoseAfter2Hour,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.glucoseAfter2Hour) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.glucoseAfter2Hour) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+
+            setScatterplotChartDataInsulinvsBMI(d3.map(filteredData, (d) => {
+                return {
+                    x: d.bodyMassIndex,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0
+                    xScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    y: d.insulin,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.insulin) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.insulin) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
         },
     }));  
 

--- a/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
+++ b/src/components/charts/ScatterplotChartWaistCircumferenceVsBMI.tsx
@@ -39,6 +39,37 @@ const ScatterplotChartWaistCircumferenceVsBMI = forwardRef<ScatterplotChartWaist
     }));
 
     useImperativeHandle(ref, () => ({
+        onStackedBarAgeGroupClick(toggledAgeGroup: boolean, ageGroup: string) {
+            // console.log("onStackedBarAgeGroupClick", toggledAgeGroup, ageGroup);
+
+            let filteredData:Array<any> = [];
+
+            if (toggledAgeGroup) {
+                // Filter original values by ageGroup and exercise level and re-render.
+                filteredData = props.data.filter((d) => 
+                    d.ageGroup === ageGroup
+                );
+
+            } else {
+                // Reset data back to original values and re-render.
+                filteredData = props.data;
+            }
+
+            // Render the charts with filtered data.
+            setScatterplotChartData(d3.map(filteredData, (d) => {
+                return {
+                    x: d.waistCircumference,
+                    xScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.waistCircumference) as number) - 1), // Ensure the minimum value > 0
+                    xScaleMax: (d3.max(props.data, (d) => d.waistCircumference) as number) + 5,
+                    y: d.bodyMassIndex,
+                    yScaleMin: Math.max(0.1, (d3.min(props.data, (d) => d.bodyMassIndex) as number) - 1), // Ensure the minimum value > 0
+                    yScaleMax: (d3.max(props.data, (d) => d.bodyMassIndex) as number) + 5,
+                    markColorField: d.markColorField,
+                    filterGender: d.filterGender,
+                    seqn: d.seqn
+                }
+            }));
+        },
         // @ts-ignore
         onStackedBarExerciseBarClick(toggledExerciseLevelBar: boolean, ageGroup: string, exerciseBarLevel: string) {
             console.log("onStackedBarExerciseBarClick", toggledExerciseLevelBar, ageGroup, exerciseBarLevel);

--- a/src/components/charts/StackedBarChartAgeVsExercise.tsx
+++ b/src/components/charts/StackedBarChartAgeVsExercise.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 import * as d3 from "d3";
 
@@ -8,7 +9,7 @@ type Group = {
     x: string;
 } & { [key: string]: number };
 
-type StackedBarChartAgeVsExerciseProps = {
+interface StackedBarChartAgeVsExerciseProps {
     height: number;
     data: {
         ageGroup: string;
@@ -18,18 +19,22 @@ type StackedBarChartAgeVsExerciseProps = {
         groupExerciseLevelVigorous: number;
         groupExerciseLevelVigorousMale: number;
         groupExerciseLevelVigorousFemale: number;
-        markColorField: string;
     }[];
 };
+
+interface StackedBarChartAgeVsExerciseRef {
+    onDonutChartGenderSliceClick: (d: any) => void;
+};
   
-const StackedBarChartAgeVsExercise = ({ height, data }: StackedBarChartAgeVsExerciseProps) => {
+const StackedBarChartAgeVsExercise = forwardRef<StackedBarChartAgeVsExerciseRef, StackedBarChartAgeVsExerciseProps>((props, ref) => {
+    const [genderDonutChartSliceName, setGenderDonutChartSliceName] = useState("");
 
     // data.map(d => console.log(d));
 
     const allGroups = ["≤17", "18-34", "35-59", "60 and older"]; // Custom order for age groups
     const allSubgroups = ["No", "Vigorous"]; // Defining the subgroups for separating the series bars.
 
-    const stackedBarChartAgevsExerciseLevel = d3.map(data, (d) => {
+    const stackedBarChartAgevsExerciseLevel = d3.map(props.data, (d) => {
         return {
             x: d.ageGroup,
             No: d.groupExerciseLevelNo,
@@ -42,12 +47,25 @@ const StackedBarChartAgeVsExercise = ({ height, data }: StackedBarChartAgeVsExer
     });
 
     // Calculate the maximum participants across all age groups for x-axis scaling
-    const maxParticipants: number = d3.max(data, d => d.groupExerciseLevelNo + d.groupExerciseLevelVigorous) || 0;
+    const maxParticipants: number = d3.max(props.data, d => d.groupExerciseLevelNo + d.groupExerciseLevelVigorous) || 0;
+   
+    useImperativeHandle(ref, () => ({
+        // @ts-ignore
+        onDonutChartGenderSliceClick(toggledSlice: boolean, sliceName: string) {
+            if (toggledSlice) {
+                setGenderDonutChartSliceName(sliceName);
+            } else {
+                setGenderDonutChartSliceName("");
+            }
+        },
+    }));    
+
+    const chartRefD3StackedBarChart: any = useRef();
 
     return (
         <>
         <D3StackedBarChart
-            height={height}
+            height={props.height}
             allGroups={allGroups}
             allSubgroups={allSubgroups}
             data={stackedBarChartAgevsExerciseLevel as unknown as Group[]}
@@ -59,9 +77,11 @@ const StackedBarChartAgeVsExercise = ({ height, data }: StackedBarChartAgeVsExer
             xAxisTicks={8}
             showXAxis={true}
             showYAxis={true}
+            genderDonutChartSliceName={genderDonutChartSliceName}
+            ref={chartRefD3StackedBarChart}
         />
         </>
     );
-};
+});
 
 export default StackedBarChartAgeVsExercise;

--- a/src/components/charts/StackedBarChartAgeVsExercise.tsx
+++ b/src/components/charts/StackedBarChartAgeVsExercise.tsx
@@ -80,7 +80,8 @@ const StackedBarChartAgeVsExercise = forwardRef<StackedBarChartAgeVsExerciseRef,
             showXAxis={true}
             showYAxis={true}
             genderDonutChartSliceName={genderDonutChartSliceName}
-            onExerciseLevelClick={props.onExerciseLevelClick}
+            onGroupClick={props.onAgeGroupClick}
+            onSubGroupClick={props.onExerciseLevelClick}
             ref={chartRefD3StackedBarChart}
         />
         </>

--- a/src/components/charts/StackedBarChartAgeVsExercise.tsx
+++ b/src/components/charts/StackedBarChartAgeVsExercise.tsx
@@ -20,6 +20,8 @@ interface StackedBarChartAgeVsExerciseProps {
         groupExerciseLevelVigorousMale: number;
         groupExerciseLevelVigorousFemale: number;
     }[];
+    onExerciseLevelClick: Array<Function> | [];
+    onAgeGroupClick: Array<Function> | [];
 };
 
 interface StackedBarChartAgeVsExerciseRef {
@@ -78,6 +80,7 @@ const StackedBarChartAgeVsExercise = forwardRef<StackedBarChartAgeVsExerciseRef,
             showXAxis={true}
             showYAxis={true}
             genderDonutChartSliceName={genderDonutChartSliceName}
+            onExerciseLevelClick={props.onExerciseLevelClick}
             ref={chartRefD3StackedBarChart}
         />
         </>

--- a/src/components/charts/scatterplot.module.css
+++ b/src/components/charts/scatterplot.module.css
@@ -7,7 +7,7 @@
     opacity: .1;
     transition: opacity;
     transition-delay: .5s;
-    transition-duration: .5s
+    transition-duration: .5s;
 }
 
 .scatterplotCircle:hover {

--- a/src/components/charts/scatterplot.module.css
+++ b/src/components/charts/scatterplot.module.css
@@ -4,9 +4,8 @@
 }
 
 .scatterplotCircle.dimmed {
-    filter: saturate(0);
-    opacity: .2;
-    transition: opacity, filter;
+    opacity: .1;
+    transition: opacity;
     transition-delay: .5s;
     transition-duration: .5s
 }

--- a/src/components/charts/stackedbar.module.css
+++ b/src/components/charts/stackedbar.module.css
@@ -1,0 +1,20 @@
+.stackedbarRect {
+    fill-opacity: 1;
+    stroke-width: 3px;
+}
+
+.stackedbarRectDimmed {
+    filter: saturate(0);
+    opacity: 0.3;
+    transition: opacity, filter;
+    transition-delay: .5s;
+    transition-duration: .5s
+}
+
+.stackedbarRect:hover {
+    cursor: pointer;
+    opacity: 1.5;
+    stroke: black;
+    fill-opacity: 1;
+    stroke-width: 3px;
+}

--- a/src/components/marks/Shape.tsx
+++ b/src/components/marks/Shape.tsx
@@ -1,0 +1,6 @@
+// Defaults used throughout for SVGs.
+
+export const CircleShape:object = {
+    radius: "4",
+    radiusSelected: "6"
+}

--- a/src/components/marks/tooltip.module.css
+++ b/src/components/marks/tooltip.module.css
@@ -4,12 +4,13 @@
     border: 1px solid #f5f5f5;
     box-shadow: 3px 3px 3px rgb(0 0 0 / 10%);
     font-size: 9px;
-    max-width: 250px;
+    max-width: 300px;
     padding: 10px;
     position: absolute;
 
     margin-left: 35px;
     transform: translateY(-50%);
+    z-index: 1000;
 }
 
 .title {
@@ -19,7 +20,7 @@
 .name {
     text-align: left;
     display: inline-block;
-    width: 200px;
+    width: 150px;
 }
 
 .topHalfContainer {

--- a/src/interactions/InteractionsDonutChartGender.tsx
+++ b/src/interactions/InteractionsDonutChartGender.tsx
@@ -3,6 +3,7 @@
 import * as d3 from "d3";
 
 import { colorScaleGender } from "../components/marks/Color";
+import { CircleShape } from "../components/marks/Shape";
 
 export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqnIdentifiers: Set<number>, sliceName: string) {
     // console.log("toggledSlice ", toggledSlice);
@@ -50,7 +51,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
         .select(".dots")
         .selectAll("circle")
             .transition().duration(1000)
-            .attr("r", 5);
+            .attr("r", CircleShape.radius);
 
         d3
         .select(".scatterplot-chart-blood-measures-vs-bmi")
@@ -58,7 +59,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
         .select(".dots")
         .selectAll("circle")
             .transition().duration(1000)
-            .attr("r", 5);
+            .attr("r", CircleShape.radius);
 
         d3
         .select(".scatterplot-chart-blood-measures-vs-bmi")
@@ -66,7 +67,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
         .select(".dots")
         .selectAll("circle")
             .transition().duration(1000)
-            .attr("r", 5);
+            .attr("r", CircleShape.radius);
     }
 
     // Handle interactions for `Waist Circumference vs. BMI` scatterplot chart.
@@ -87,7 +88,7 @@ export function onDonutChartGenderSliceClick(toggledSlice: boolean, selectedSeqn
         .select(".dots")
         .selectAll("circle")
             .transition().duration(1000)
-            .attr("r", 5);
+            .attr("r", CircleShape.radius);
     }
 
 

--- a/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
@@ -2,6 +2,8 @@
 
 import * as d3 from "d3";
 
+import { CircleShape } from "../components/marks/Shape";
+
 export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean, d: SVGCircleElement, markColorScale: d3.ScaleOrdinal<any, any>, xScale: d3.ScaleLinear, yScale: d3.ScaleLinear) {
 
     // Hide all points that are not selected.
@@ -15,7 +17,7 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
         // .style("stroke", markColorScale(d.markColorField))
         .style("stroke-width", "2px")
         .style("fill-opacity", 0.3)
-        .attr("r", 5)
+        .attr("r", CircleShape.radius)
         .attr("data-selected-dot", null);
         
     if (!toggledPoint) {
@@ -33,7 +35,7 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
             .style("opacity", 1)
             .style("fill-opacity", 0.8)
             .style("filter", "saturate(1)")
-            .attr("r", 8)
+            .attr("r", CircleShape.radiusSelected)
             .attr("data-selected-dot", true);
 
         // Draw the line between the selected dots. The delay of 1 second is necessary.
@@ -102,7 +104,7 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
             .style("stroke", markColorScale(d.markColorField))
             .style("stroke-width", "2px")
             .style("fill-opacity", 0.3)
-            .attr("r", 5)
+            .attr("r", CircleShape.radius)
             .attr("data-selected-dot", null);
 
         d3

--- a/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
+++ b/src/interactions/InteractionsScatterplotChartBloodMeasuresVsBMI.tsx
@@ -4,23 +4,29 @@ import * as d3 from "d3";
 
 export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean, d: SVGCircleElement, markColorScale: d3.ScaleOrdinal<any, any>, xScale: d3.ScaleLinear, yScale: d3.ScaleLinear) {
 
+    // Hide all points that are not selected.
+    d3
+    .select(".scatterplot-chart-blood-measures-vs-bmi")
+    .selectAll(".dots")
+    .selectAll("circle")
+        .style("filter", "saturate(0)")
+        .style("opacity", 0.2)
+        .transition().duration(1000)
+        // .style("stroke", markColorScale(d.markColorField))
+        .style("stroke-width", "2px")
+        .style("fill-opacity", 0.3)
+        .attr("r", 5)
+        .attr("data-selected-dot", null);
+        
     if (!toggledPoint) {
             
         // ----------------------------------------------
-
-        // Hide all points that are not selected.
-        d3
-        .select(".scatterplot-chart-blood-measures-vs-bmi")
-        .selectAll(".dots")
-        .selectAll("circle")
-            .style("filter", "saturate(0)")
-            .style("opacity", 0);
             
         // Change the highlight of the selected dots between the charts.
         d3
         .select(".scatterplot-chart-blood-measures-vs-bmi")
         .selectAll(".dots")
-        .selectAll("[data-seqn='" + d.seqn + "']")
+        .selectAll("[data-seqn='" + d.seqn + "']") 
             .transition().duration(1000)
             .style("stroke", "black")
             .style("stroke-width", "4px")
@@ -31,6 +37,10 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
             .attr("data-selected-dot", true);
 
         // Draw the line between the selected dots. The delay of 1 second is necessary.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll("[data-selected-path='true']")
+            .remove();
         setTimeout(() => {
             let dataSelectedPoints = [];
 
@@ -62,8 +72,9 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
             const group = 
             svg
             .append("g")
-                .attr("transform", "translate(-18, -66)")
-                .attr("overflow", "visible");
+                .attr("transform", "translate(-21, -135)") // -70
+                .attr("overflow", "visible")
+                .attr("data-selected-path", "true");
 
             group
             .append("path")
@@ -71,9 +82,8 @@ export function onScatterplotChartBloodMeasuresVsBMIClick(toggledPoint: boolean,
             .attr("d", lineGenerator) // Use the line generator to create the path
             .attr("stroke", "#399D3E") // Set the line color
             .attr("stroke-width", 4) // Set the line width
-            .attr("stroke-dasharray", "4, 8, 4")
-            .attr("data-selected-path", "true"); 
-            }, 1000);
+            .attr("stroke-dasharray", "4, 8, 4"); 
+            }, 500);
 
     } else {
         // Hide all points that are not selected.

--- a/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
+++ b/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
@@ -1,0 +1,54 @@
+// @ts-nocheck
+
+import * as d3 from "d3";
+
+export function onStackedBarChartAgeVsExerciseClick(toggledBarSubgroup: boolean, group: any, subgroup: any) {
+
+    // console.log("interactive", toggledBarSubgroup, group, subgroup);
+    if (toggledBarSubgroup) {
+            
+        // ----------------------------------------------
+
+        // Hide all exercise level bars not selected in Exercise Level vs. Age Group chart.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-bar='false']")
+            .style("filter", "saturate(0)")
+            .style("opacity", "0.3")
+            .style("transition", "opacity, filter")
+            .style("transition-delay", ".5s")
+            .style("transition-duration", ".5s");
+
+        // Retransition the dots to make them fade in.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("opacity", 0.2)
+            .transition().duration(1500)
+            .style("filter", "saturate(0)")
+            .style("opacity", 1);
+
+    } else {
+
+        // Show all exercise level bars not selected in Exercise Level vs. Age Group chart.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-bar='false']")
+            .style("filter", "saturate(1)")
+            .style("opacity", "0.9")
+            .style("transition", "opacity, filter")
+            .style("transition-delay", ".5s")
+            .style("transition-duration", ".5s");
+
+        // Retransition the dots to make them fade in.
+        d3
+        .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("opacity", 0);
+    }
+
+}

--- a/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
+++ b/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
@@ -2,12 +2,69 @@
 
 import * as d3 from "d3";
 
-export function onStackedBarChartAgeVsExerciseClick(toggledBarSubgroup: boolean, group: any, subgroup: any) {
+export function onStackedBarChartAgeVsExerciseClickAgeGroup(toggledBarGroup: boolean, groupName: string) {
 
-    // console.log("interactive", toggledBarSubgroup, group, subgroup);
+    // console.log("AgeGroup interactive", toggledBarGroup);
+
+    // ----------------------------------------------
+    // Bar Groups
+    if (toggledBarGroup) {
+        // Hide all exercise level bars not selected in Exercise Level vs. Age Group chart.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-group='false']")
+            .style("filter", "saturate(0)")
+            .style("opacity", "0.3")
+            .style("transition", "opacity, filter")
+            .style("transition-delay", ".5s")
+            .style("transition-duration", ".5s");
+            
+    } else {
+
+        // Disable any selected age groups.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-axis-label='true']")
+            .attr("data-selected-axis-label", "false")
+            .attr("fill", "black")
+            .style("font-size", "12px")
+            .style("font-weight", "normal");
+
+        // Show all exercise level bars not selected in Exercise Level vs. Age Group chart.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-group='false']")
+            .style("filter", "saturate(1)")
+            .style("opacity", "0.9")
+            .style("transition", "opacity, filter")
+            .style("transition-delay", ".5s")
+            .style("transition-duration", ".5s");
+
+    }
+}
+
+export function onStackedBarChartAgeVsExerciseClickExerciseLevel(toggledBarSubgroup: boolean, group?: any, subgroup?: any) {
+
+    // console.log("ExerciseLevel interactive", toggledBarSubgroup, group, subgroup);
+
+    // ----------------------------------------------
+    // Bar Subgroups
     if (toggledBarSubgroup) {
             
         // ----------------------------------------------
+
+        // Disable any selected age groups.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-axis-label='true']")
+            .attr("data-selected-axis-label", "false")
+            .attr("fill", "black")
+            .style("font-size", "12px")
+            .style("font-weight", "normal");
 
         // Hide all exercise level bars not selected in Exercise Level vs. Age Group chart.
         d3
@@ -20,6 +77,17 @@ export function onStackedBarChartAgeVsExerciseClick(toggledBarSubgroup: boolean,
             .style("transition-delay", ".5s")
             .style("transition-duration", ".5s");
 
+        // Make sure to enable the exercise subgroup selected.
+        d3
+        .select(".bar-chart-age-vs-exercise-level")
+        // .select("#barSubgroup0")
+        .selectAll("[data-selected-bar='true']")
+            .style("filter", "saturate(1)")
+            .style("opacity", "0.9")
+            .style("transition", "opacity, filter")
+            .style("transition-delay", ".5s")
+            .style("transition-duration", ".5s");
+
         // Retransition the dots to make them fade in.
         d3
         .select(".scatterplot-chart-blood-measures-vs-bmi")
@@ -27,7 +95,6 @@ export function onStackedBarChartAgeVsExerciseClick(toggledBarSubgroup: boolean,
         .selectAll("circle")
             .style("opacity", 0.2)
             .transition().duration(1500)
-            .style("filter", "saturate(0)")
             .style("opacity", 1);
 
     } else {

--- a/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
+++ b/src/interactions/InteractionsStackedBarChartAgeVsExercise.tsx
@@ -97,6 +97,15 @@ export function onStackedBarChartAgeVsExerciseClickExerciseLevel(toggledBarSubgr
             .transition().duration(1500)
             .style("opacity", 1);
 
+        // Retransition the dots to make them fade in.
+        d3
+        .select(".scatterplot-chart-waist-cirumference-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("opacity", 0.2)
+            .transition().duration(1500)
+            .style("opacity", 1);
+
     } else {
 
         // Show all exercise level bars not selected in Exercise Level vs. Age Group chart.
@@ -113,6 +122,13 @@ export function onStackedBarChartAgeVsExerciseClickExerciseLevel(toggledBarSubgr
         // Retransition the dots to make them fade in.
         d3
         .select(".scatterplot-chart-blood-measures-vs-bmi")
+        .selectAll(".dots")
+        .selectAll("circle")
+            .style("opacity", 0);
+
+        // Retransition the dots to make them fade in.
+        d3
+        .select(".scatterplot-chart-waist-cirumference-vs-bmi")
         .selectAll(".dots")
         .selectAll("circle")
             .style("opacity", 0);


### PR DESCRIPTION
- [x] Create a selection by age group. Dim out non-selected age-groups. (Acheme)
- [x] When selecting an age group or even exercise-level (vigorous, no) within the group change the Blood Measures vs. BMI scatterplots to filter out dots that are not in that group. (Srushti)
- [x] When selecting an age group or even exercise-level (vigorous, no) within the group change the Waist Circumference vs. BMI scatterplots to filter out dots that are not in that group. (Zachary)
- [x] When selecting an age group or even exercise-level (vigorous, no) within the group change the Donut Gender chart updates it's percentage values and total participant count. (Zachary)

**Final Output Showing Selection by Exercise Level and Age Group**

![Image](https://github.com/user-attachments/assets/61774aed-142c-4aac-8876-c6eec1562325)